### PR TITLE
fix(ssr): correct integration defects, bump to Nest 11, add Angular runtime + debug logger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,8 +45,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -75,8 +71,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -107,8 +101,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18', '20', '22']
+        node-version: ['20', '22', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -340,47 +340,33 @@ The defaults use NestJS 11 / Express 5 / path-to-regexp v8 splat syntax: `'{/*sp
 
 ## Request and Response Injection
 
-How you access the Express request/response in your Angular components depends on which engine your Angular SSR setup is using.
+This module wires the same Angular DI tokens that `AngularAppEngine` and `AngularNodeAppEngine` expose natively, so every engine path (including `CommonEngine`) lets you reach the Express `Request` and `Response` from inside Angular components.
 
-### CommonEngine
+- `REQUEST` — a Web Fetch `Request` built from the incoming Express request (URL, method, headers).
+- `REQUEST_CONTEXT` — a plain object `{ request, response }` carrying the raw Express objects for direct access (e.g. to set a status code).
 
-This module registers the Express `Request` and `Response` as per-render Angular providers under the `REQUEST` and `RESPONSE` string tokens:
+Both tokens come from `@angular/core` and are re-exported from this package so consumers don't need a separate Angular import in their NestJS module wiring. The library ships an `SSRRequestContext` type alias for `REQUEST_CONTEXT`.
 
 ```typescript
-import { Component, Inject, Optional, PLATFORM_ID } from '@angular/core';
+import { Component, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
-import type { Response } from 'express';
-import { RESPONSE } from '@lexmata/nestjs-angular-ssr/tokens';
+import { REQUEST_CONTEXT } from '@lexmata/nestjs-angular-ssr';
+import type { SSRRequestContext } from '@lexmata/nestjs-angular-ssr';
 
 @Component({
   selector: 'app-not-found',
   template: '<h1>404 - Page Not Found</h1>',
 })
 export class NotFoundComponent {
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: object,
-    @Optional() @Inject(RESPONSE) private response: Response | null,
-  ) {
-    if (isPlatformServer(this.platformId) && this.response) {
-      this.response.status(404);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly ctx = inject<SSRRequestContext | null>(REQUEST_CONTEXT, { optional: true });
+
+  constructor() {
+    if (isPlatformServer(this.platformId) && this.ctx) {
+      this.ctx.response.status(404);
     }
   }
 }
-```
-
-> **Note**: `REQUEST` and `RESPONSE` are string tokens (`'ANGULAR_SSR_REQUEST'` and `'ANGULAR_SSR_RESPONSE'`).
-
-### AngularNodeAppEngine / AngularAppEngine
-
-The newer engines provide their own `REQUEST` and `REQUEST_CONTEXT` injection tokens via `@angular/ssr` — use those directly. This module forwards `{ response }` as the `requestContext` so you can also retrieve the Express response there:
-
-```typescript
-import { inject } from '@angular/core';
-import { REQUEST_CONTEXT } from '@angular/ssr';
-import type { Response } from 'express';
-
-const ctx = inject<{ response?: Response }>(REQUEST_CONTEXT);
-ctx.response?.status(404);
 ```
 
 ## Debug Logging
@@ -498,18 +484,18 @@ Your Angular project should have a server entry point that exports the Angular a
 nestjs-angular-ssr/
 ├── lib/
 │   ├── index.ts                          # Public API re-exports
-│   ├── tokens.ts                         # REQUEST / RESPONSE DI tokens
+│   ├── tokens.ts                         # ANGULAR_SSR_OPTIONS internal token
 │   ├── angular-ssr.module.ts             # NestJS dynamic module (forRoot / forRootAsync)
 │   ├── angular-ssr.service.ts            # SSR rendering + cache management
 │   ├── angular-ssr.middleware.ts         # Express middleware for SSR + static files
+│   ├── debug-logger.ts                   # ANGULAR_SSR_DEBUG env-gated logger
 │   ├── interfaces/
 │   │   ├── angular-ssr-module-options.interface.ts
 │   │   ├── cache-key-generator.interface.ts
 │   │   └── cache-storage.interface.ts
 │   └── cache/
-│       ├── in-memory-cache-storage.ts    # Default cache backend
+│       ├── in-memory-cache-storage.ts    # Default LRU-bounded cache backend
 │       └── url-cache-key-generator.ts    # Default cache key strategy
-├── tokens/                               # Secondary entry point for @lexmata/nestjs-angular-ssr/tokens
 ├── example/                              # Full working NestJS + Angular SSR example app
 ├── docs/                                 # GitHub Pages API docs
 ├── .github/
@@ -518,7 +504,7 @@ nestjs-angular-ssr/
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── ISSUE_TEMPLATE/                   # Bug report + feature request templates
 │   └── workflows/
-│       ├── ci.yml                        # Lint, typecheck, test (Node 18/20/22), build
+│       ├── ci.yml                        # Lint, typecheck, test (Node 20/22/24), build
 │       └── release.yml                   # Publish to npm + GitHub Packages on release
 ├── package.json
 ├── tsconfig.json

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn add @lexmata/nestjs-angular-ssr
 ## Prerequisites
 
 - Node.js >= 20.0.0
-- NestJS >= 10.0.0 (NestJS 11 supported — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5) below)
+- NestJS >= 11.0.0 (Express 5 / path-to-regexp v8)
 - Angular >= 19.0.0 with SSR configured
 
 ## Usage
@@ -311,24 +311,24 @@ NODE_ENV=production
 
 ### `forRoot()` Options
 
-| Property            | Type                               | Default                                 | Description                                                                                            |
-| ------------------- | ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                                            |
-| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                                           |
-| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                                    |
-| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                                        |
-| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds)                 |
-| `renderPath`        | `string \| string[]?`              | `'(.*)'`                                | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5) |
-| `rootStaticPath`    | `string?`                          | `'(.*)'`                                | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5)   |
-| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                                |
-| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                                  |
-| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                                   |
-| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                                         |
-| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                                          |
+| Property            | Type                               | Default                                 | Description                                                                            |
+| ------------------- | ---------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
+| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                            |
+| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                           |
+| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                    |
+| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                        |
+| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds) |
+| `renderPath`        | `string \| string[]?`              | `'{/*splat}'`                           | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes)      |
+| `rootStaticPath`    | `string?`                          | `'{/*splat}'`                           | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes)        |
+| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                |
+| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                  |
+| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                   |
+| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                         |
+| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                          |
 
-### Wildcard routes (NestJS 11 / Express 5)
+### Wildcard routes
 
-The defaults use `(.*)`, which is accepted by both `path-to-regexp` v6 (NestJS 10) and v8 (NestJS 11 / Express 5). Bare `'*'` works only on NestJS 10 — under NestJS 11 it throws `Missing parameter name`. If you want the v11-native syntax, override with `'/{*splat}'`.
+The defaults use NestJS 11 / Express 5 / path-to-regexp v8 splat syntax: `'{/*splat}'`. The braces make the splat optional so the pattern matches both root `/` and every nested path. If you only need to mount under a sub-path, override with something like `'/app/*splat'`.
 
 ### Cache Options
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ yarn add @lexmata/nestjs-angular-ssr
 
 ## Prerequisites
 
-- Node.js >= 18.0.0
-- NestJS >= 10.0.0
+- Node.js >= 20.0.0
+- NestJS >= 10.0.0 (NestJS 11 supported — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5) below)
 - Angular >= 19.0.0 with SSR configured
 
 ## Usage
@@ -311,18 +311,24 @@ NODE_ENV=production
 
 ### `forRoot()` Options
 
-| Property            | Type                              | Default                                 | Description                                   |
-| ------------------- | --------------------------------- | --------------------------------------- | --------------------------------------------- |
-| `browserDistFolder` | `string`                          | **required**                            | Path to the Angular browser build directory   |
-| `bootstrap`         | `() => Promise<AngularAppEngine>` | **required**                            | Function that returns the Angular SSR engine  |
-| `serverDistFolder`  | `string?`                         | -                                       | Path to the server bundle directory           |
-| `indexHtml`         | `string?`                         | `{browserDistFolder}/index.server.html` | Path to the index.html template               |
-| `renderPath`        | `string \| string[]?`             | `'*'`                                   | Route path(s) to render the Angular app       |
-| `rootStaticPath`    | `string \| RegExp?`               | `'*'`                                   | Path pattern for serving static files         |
-| `extraProviders`    | `StaticProvider[]?`               | -                                       | Additional providers for SSR                  |
-| `inlineCriticalCss` | `boolean?`                        | `true`                                  | Inline critical CSS to reduce render-blocking |
-| `cache`             | `boolean \| CacheOptions?`        | `true`                                  | Cache configuration                           |
-| `errorHandler`      | `ErrorHandler?`                   | -                                       | Custom error handler function                 |
+| Property            | Type                               | Default                                 | Description                                                                                            |
+| ------------------- | ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                                            |
+| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                                           |
+| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                                    |
+| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                                        |
+| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds)                 |
+| `renderPath`        | `string \| string[]?`              | `'(.*)'`                                | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5) |
+| `rootStaticPath`    | `string?`                          | `'(.*)'`                                | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes-nestjs-11--express-5)   |
+| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                                |
+| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                                  |
+| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                                   |
+| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                                         |
+| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                                          |
+
+### Wildcard routes (NestJS 11 / Express 5)
+
+The defaults use `(.*)`, which is accepted by both `path-to-regexp` v6 (NestJS 10) and v8 (NestJS 11 / Express 5). Bare `'*'` works only on NestJS 10 — under NestJS 11 it throws `Missing parameter name`. If you want the v11-native syntax, override with `'/{*splat}'`.
 
 ### Cache Options
 
@@ -334,7 +340,11 @@ NODE_ENV=production
 
 ## Request and Response Injection
 
-Access Express `Request` and `Response` objects in your Angular components using the provided string tokens:
+How you access the Express request/response in your Angular components depends on which engine your Angular SSR setup is using.
+
+### CommonEngine
+
+This module registers the Express `Request` and `Response` as per-render Angular providers under the `REQUEST` and `RESPONSE` string tokens:
 
 ```typescript
 import { Component, Inject, Optional, PLATFORM_ID } from '@angular/core';
@@ -358,7 +368,46 @@ export class NotFoundComponent {
 }
 ```
 
-> **Note**: `REQUEST` and `RESPONSE` are string tokens (`'ANGULAR_SSR_REQUEST'` and `'ANGULAR_SSR_RESPONSE'`) that work with both NestJS and Angular dependency injection systems.
+> **Note**: `REQUEST` and `RESPONSE` are string tokens (`'ANGULAR_SSR_REQUEST'` and `'ANGULAR_SSR_RESPONSE'`).
+
+### AngularNodeAppEngine / AngularAppEngine
+
+The newer engines provide their own `REQUEST` and `REQUEST_CONTEXT` injection tokens via `@angular/ssr` — use those directly. This module forwards `{ response }` as the `requestContext` so you can also retrieve the Express response there:
+
+```typescript
+import { inject } from '@angular/core';
+import { REQUEST_CONTEXT } from '@angular/ssr';
+import type { Response } from 'express';
+
+const ctx = inject<{ response?: Response }>(REQUEST_CONTEXT);
+ctx.response?.status(404);
+```
+
+## Debug Logging
+
+Set the `ANGULAR_SSR_DEBUG` environment variable to enable verbose tracing across the module, service, and middleware. Warnings and errors are always emitted; only `log` / `debug` / `verbose` levels are gated.
+
+```bash
+# Enable everything
+ANGULAR_SSR_DEBUG=1 node dist/main.js
+
+# Enable only specific contexts (case-insensitive, comma-separated)
+ANGULAR_SSR_DEBUG=AngularSSRMiddleware,AngularSSRService node dist/main.js
+```
+
+Accepted "enable all" values: `1`, `true`, `yes`, `on`, `all`, `*`. The flag is re-read on every log call, so you can toggle it at runtime by mutating `process.env` from a maintenance endpoint or a debug tool — no restart required.
+
+You can also branch on the flag yourself when constructing an expensive log message:
+
+```typescript
+import { isDebugEnabled } from '@lexmata/nestjs-angular-ssr';
+
+if (isDebugEnabled('AngularSSRService')) {
+  // build a heavy debug payload
+}
+```
+
+The exported `DebugLogger` class can be reused in your own SSR-related code if you want a logger that obeys the same flag.
 
 ## Custom Cache Storage
 
@@ -505,11 +554,11 @@ pnpm publish --access public
 
 ## Related Repos
 
-| Repo | Relationship |
-|---|---|
-| `lexmata-app-frontend` | Consumer -- uses this module for Angular SSR in the main app |
-| `lexmata-marketing` | Consumer -- uses this module for the marketing site SSR |
-| `lexmata-admin-frontend` | Consumer -- uses this module for the admin panel SSR |
+| Repo                     | Relationship                                                 |
+| ------------------------ | ------------------------------------------------------------ |
+| `lexmata-app-frontend`   | Consumer -- uses this module for Angular SSR in the main app |
+| `lexmata-marketing`      | Consumer -- uses this module for the marketing site SSR      |
+| `lexmata-admin-frontend` | Consumer -- uses this module for the admin panel SSR         |
 
 ## Contributing
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,7 +200,7 @@ export default tseslint.config(
       'n/no-unsupported-features/es-syntax': 'off', // Using TypeScript
       'n/no-unsupported-features/node-builtins': [
         'error',
-        { version: '>=18.0.0' },
+        { version: '>=20.0.0' },
       ],
       'n/prefer-global/buffer': ['error', 'always'],
       'n/prefer-global/console': ['error', 'always'],

--- a/lib/angular-ssr.e2e.spec.ts
+++ b/lib/angular-ssr.e2e.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * End-to-end test that boots a real NestJS application with the SSR module
+ * mounted, then issues real HTTP requests through Express. This exists to
+ * catch regressions that mocked unit tests cannot — most importantly, that
+ * the wildcard route default (`'*splat'`) is actually accepted by the real
+ * path-to-regexp matcher inside NestJS, not just by a mocked
+ * `MiddlewareConsumer`.
+ */
+
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { AngularSSRModule } from './angular-ssr.module';
+import { AngularSSRService } from './angular-ssr.service';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+
+@Module({
+  imports: [
+    AngularSSRModule.forRoot({
+      browserDistFolder: '/tmp/never-read-during-tests',
+      bootstrap: () =>
+        Promise.resolve({
+          // Minimal AngularAppEngine-shaped stub.
+          handle: vi.fn().mockResolvedValue({
+            text: () => Promise.resolve('<html><body>e2e ok</body></html>'),
+          }),
+        }),
+      // The middleware otherwise refuses to render '/api/*' — the e2e
+      // exercises that the middleware's skip rule short-circuits before SSR.
+    }),
+  ],
+})
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- token class for Nest module decorator
+class E2EAppModule {}
+
+describe('AngularSSRModule (e2e wildcard routing)', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    app = await NestFactory.create(E2EAppModule, { logger: ['error', 'warn'] });
+    await app.listen(0);
+    const server = app.getHttpServer() as { address: () => AddressInfo };
+    const port = server.address().port;
+    baseUrl = `http://127.0.0.1:${String(port)}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('mounts middleware on the *splat default and serves a GET / through SSR', async () => {
+    const res = await fetch(`${baseUrl}/`);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(body).toContain('e2e ok');
+  });
+
+  it('serves nested routes through the same wildcard', async () => {
+    const res = await fetch(`${baseUrl}/products/123/details`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('e2e ok');
+  });
+
+  it('skips the default /api prefix without invoking SSR', async () => {
+    // Without an /api controller, Nest returns 404. The point is that the
+    // SSR middleware must not have intercepted the request — if it had, we
+    // would see the e2e ok HTML body instead.
+    const res = await fetch(`${baseUrl}/api/missing`);
+    const body = await res.text();
+    expect(body).not.toContain('e2e ok');
+  });
+
+  it('exposes AngularSSRService for runtime cache management', () => {
+    const service = app.get(AngularSSRService);
+    expect(service).toBeInstanceOf(AngularSSRService);
+  });
+});

--- a/lib/angular-ssr.e2e.spec.ts
+++ b/lib/angular-ssr.e2e.spec.ts
@@ -7,6 +7,7 @@
  * `MiddlewareConsumer`.
  */
 
+import { AngularAppEngine } from '@angular/ssr';
 import { Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -15,19 +16,21 @@ import { AngularSSRService } from './angular-ssr.service';
 import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 
+const buildStubEngine = (): AngularAppEngine => {
+  const engine = Object.create(AngularAppEngine.prototype) as AngularAppEngine & {
+    handle: ReturnType<typeof vi.fn>;
+  };
+  engine.handle = vi.fn().mockResolvedValue({
+    text: () => Promise.resolve('<html><body>e2e ok</body></html>'),
+  });
+  return engine;
+};
+
 @Module({
   imports: [
     AngularSSRModule.forRoot({
       browserDistFolder: '/tmp/never-read-during-tests',
-      bootstrap: () =>
-        Promise.resolve({
-          // Minimal AngularAppEngine-shaped stub.
-          handle: vi.fn().mockResolvedValue({
-            text: () => Promise.resolve('<html><body>e2e ok</body></html>'),
-          }),
-        }),
-      // The middleware otherwise refuses to render '/api/*' — the e2e
-      // exercises that the middleware's skip rule short-circuits before SSR.
+      bootstrap: () => Promise.resolve(buildStubEngine()),
     }),
   ],
 })

--- a/lib/angular-ssr.e2e.spec.ts
+++ b/lib/angular-ssr.e2e.spec.ts
@@ -1,8 +1,8 @@
 /**
  * End-to-end test that boots a real NestJS application with the SSR module
- * mounted, then issues real HTTP requests through Express. This exists to
- * catch regressions that mocked unit tests cannot — most importantly, that
- * the wildcard route default (`'*splat'`) is actually accepted by the real
+ * mounted, then issues real HTTP requests through Express. Exists to catch
+ * regressions that mocked unit tests cannot — most importantly, that the
+ * wildcard route default (`'{/*splat}'`) is actually accepted by the real
  * path-to-regexp matcher inside NestJS, not just by a mocked
  * `MiddlewareConsumer`.
  */
@@ -53,7 +53,7 @@ describe('AngularSSRModule (e2e wildcard routing)', () => {
     await app.close();
   });
 
-  it('mounts middleware on the *splat default and serves a GET / through SSR', async () => {
+  it('mounts middleware on the splat default and serves a GET / through SSR', async () => {
     const res = await fetch(`${baseUrl}/`);
     const body = await res.text();
 

--- a/lib/angular-ssr.middleware.spec.ts
+++ b/lib/angular-ssr.middleware.spec.ts
@@ -133,6 +133,26 @@ describe('AngularSSRMiddleware', () => {
 
         expect(mockSSRService.render).toHaveBeenCalled();
       });
+
+      it('emits a bypass debug log when ANGULAR_SSR_DEBUG is enabled', async () => {
+        const request = createMockRequest({ originalUrl: '/api/anything' });
+        const response = createMockResponse();
+
+        const previous = process.env.ANGULAR_SSR_DEBUG;
+        process.env.ANGULAR_SSR_DEBUG = '1';
+        try {
+          await middleware.use(request, response, mockNext);
+        } finally {
+          if (previous === undefined) {
+            Reflect.deleteProperty(process.env, 'ANGULAR_SSR_DEBUG');
+          } else {
+            process.env.ANGULAR_SSR_DEBUG = previous;
+          }
+        }
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockSSRService.render).not.toHaveBeenCalled();
+      });
     });
 
     describe('static file requests', () => {

--- a/lib/angular-ssr.middleware.spec.ts
+++ b/lib/angular-ssr.middleware.spec.ts
@@ -4,16 +4,14 @@ import type { AngularSSRService } from './angular-ssr.service';
 import type { AngularSSRModuleOptions } from './interfaces';
 import type { NextFunction, Request, Response } from 'express';
 
-// Mock Request
 const createMockRequest = (overrides: Partial<Request> = {}): Request =>
   ({
+    method: 'GET',
     originalUrl: '/test-page',
     url: '/test-page',
-    method: 'GET',
     ...overrides,
   }) as unknown as Request;
 
-// Mock Response
 const createMockResponse = (overrides: Partial<Response> = {}): Response =>
   ({
     headersSent: false,
@@ -67,6 +65,74 @@ describe('AngularSSRMiddleware', () => {
 
       expect(mockNext).toHaveBeenCalled();
       expect(mockSSRService.render).not.toHaveBeenCalled();
+    });
+
+    describe('non-GET methods', () => {
+      for (const method of ['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']) {
+        it(`bypasses SSR for ${method}`, async () => {
+          const request = createMockRequest({ method });
+          const response = createMockResponse();
+
+          await middleware.use(request, response, mockNext);
+
+          expect(mockNext).toHaveBeenCalled();
+          expect(mockSSRService.render).not.toHaveBeenCalled();
+        });
+      }
+
+      it('renders for HEAD', async () => {
+        mockSSRService.render.mockResolvedValue('<html></html>');
+        const request = createMockRequest({ method: 'HEAD' });
+        const response = createMockResponse();
+
+        await middleware.use(request, response, mockNext);
+
+        expect(mockSSRService.render).toHaveBeenCalled();
+      });
+    });
+
+    describe('configurable skipPaths', () => {
+      it('respects a custom string prefix', async () => {
+        middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
+          ...mockOptions,
+          skipPaths: ['/internal'],
+        });
+        const request = createMockRequest({ originalUrl: '/internal/secrets' });
+        const response = createMockResponse();
+
+        await middleware.use(request, response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockSSRService.render).not.toHaveBeenCalled();
+      });
+
+      it('respects a regular expression', async () => {
+        middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
+          ...mockOptions,
+          skipPaths: [/^\/v\d+\//],
+        });
+        const request = createMockRequest({ originalUrl: '/v1/data' });
+        const response = createMockResponse();
+
+        await middleware.use(request, response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockSSRService.render).not.toHaveBeenCalled();
+      });
+
+      it('does not apply default /api skip when skipPaths is empty', async () => {
+        mockSSRService.render.mockResolvedValue('<html></html>');
+        middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
+          ...mockOptions,
+          skipPaths: [],
+        });
+        const request = createMockRequest({ originalUrl: '/api/users' });
+        const response = createMockResponse();
+
+        await middleware.use(request, response, mockNext);
+
+        expect(mockSSRService.render).toHaveBeenCalled();
+      });
     });
 
     describe('static file requests', () => {
@@ -142,7 +208,22 @@ describe('AngularSSRMiddleware', () => {
       expect(mockNext).not.toHaveBeenCalled();
     });
 
-    it('should call next when render returns null', async () => {
+    it('does not double-respond when service.render() already wrote a response', async () => {
+      const response = createMockResponse({ headersSent: false });
+      mockSSRService.render.mockImplementation(() => {
+        (response as unknown as { headersSent: boolean }).headersSent = true;
+        return Promise.resolve(null);
+      });
+
+      const request = createMockRequest();
+
+      await middleware.use(request, response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(response.send).not.toHaveBeenCalled();
+    });
+
+    it('should call next when render returns null without writing response', async () => {
       mockSSRService.render.mockResolvedValue(null);
 
       const request = createMockRequest();
@@ -167,26 +248,66 @@ describe('AngularSSRMiddleware', () => {
       expect(mockNext).toHaveBeenCalledWith(error);
     });
 
-    it('should not call next when error handler is set and called', async () => {
+    it('invokes errorHandler when render throws (regression: middleware used to silently hang)', async () => {
       const error = new Error('Render error');
       mockSSRService.render.mockRejectedValue(error);
 
-      const errorHandler = vi.fn();
-      const optionsWithHandler: AngularSSRModuleOptions = {
+      const errorHandler = vi.fn((_e, _req, res: Response) => {
+        res.status(500).send('error page');
+        (res as unknown as { headersSent: boolean }).headersSent = true;
+      });
+      middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
         ...mockOptions,
         errorHandler,
-      };
-      middleware = new AngularSSRMiddleware(
-        mockSSRService as unknown as AngularSSRService,
-        optionsWithHandler,
-      );
+      });
 
       const request = createMockRequest();
       const response = createMockResponse();
 
       await middleware.use(request, response, mockNext);
 
+      expect(errorHandler).toHaveBeenCalledWith(error, request, response);
       expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('still forwards to next() when errorHandler is set but did not write a response', async () => {
+      const error = new Error('Render error');
+      mockSSRService.render.mockRejectedValue(error);
+
+      const errorHandler = vi.fn();
+      middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
+        ...mockOptions,
+        errorHandler,
+      });
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+
+      await middleware.use(request, response, mockNext);
+
+      expect(errorHandler).toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+
+    it('logs but does not crash when the user errorHandler itself throws', async () => {
+      const error = new Error('Render error');
+      mockSSRService.render.mockRejectedValue(error);
+
+      const errorHandler = vi.fn(() => {
+        throw new Error('handler exploded');
+      });
+      middleware = new AngularSSRMiddleware(mockSSRService as unknown as AngularSSRService, {
+        ...mockOptions,
+        errorHandler,
+      });
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+
+      await middleware.use(request, response, mockNext);
+
+      // headersSent stayed false → still hand to next() with the original error.
+      expect(mockNext).toHaveBeenCalledWith(error);
     });
 
     it('should use url fallback when originalUrl is undefined', async () => {

--- a/lib/angular-ssr.middleware.ts
+++ b/lib/angular-ssr.middleware.ts
@@ -46,39 +46,34 @@ export class AngularSSRMiddleware implements NestMiddleware {
     const url = req.originalUrl || req.url;
     const bypass = this.bypassReason(req, res, url);
     if (bypass) {
-      this.logger.debug(`bypass ${req.method} ${url}: ${bypass}`);
+      if (this.logger.enabled()) {
+        this.logger.debug(`bypass ${req.method} ${url}: ${bypass}`);
+      }
       next();
       return;
     }
 
-    this.logger.debug(`render ${req.method} ${url}`);
-
     try {
       const html = await this.ssrService.render(req, res);
 
-      // The configured errorHandler may have written a response from inside
-      // service.render(); never double-respond.
-      if (this.responseAlreadySent(res)) {
-        this.logger.debug(`response already sent by service for ${url}`);
+      if (res.headersSent) {
         return;
       }
 
       if (html === null) {
-        this.logger.debug(`null render result for ${url}, deferring to next()`);
         next();
         return;
       }
 
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.send(html);
-      this.logger.debug(`sent ${String(html.length)} bytes for ${url}`);
     } catch (error) {
       this.handleRenderError(error as Error, req, res, next);
     }
   }
 
   private bypassReason(req: Request, res: Response, url: string): string | null {
-    if (this.responseAlreadySent(res)) {
+    if (res.headersSent) {
       return 'response headers already sent';
     }
     if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -93,22 +88,13 @@ export class AngularSSRMiddleware implements NestMiddleware {
     return null;
   }
 
-  /**
-   * Read `res.headersSent` through a structural cast so the linter doesn't
-   * narrow it to a constant after the first early-return check — the value
-   * mutates whenever the user errorHandler writes to the response.
-   */
-  private responseAlreadySent(res: Response): boolean {
-    return (res as { headersSent: boolean }).headersSent;
-  }
-
   private handleRenderError(error: Error, req: Request, res: Response, next: NextFunction): void {
     this.logger.error('SSR rendering error', error);
 
-    // Errors thrown before the service's inner try/catch (e.g. engine not
-    // initialized) bypass the user's errorHandler. Invoke it here as a
-    // safety net so the request never silently hangs.
-    if (this.options.errorHandler && !this.responseAlreadySent(res)) {
+    // Service throws bypass the user's errorHandler when raised before its
+    // inner try/catch (e.g. engine not yet initialised) — re-invoke here so
+    // the request never silently hangs.
+    if (this.options.errorHandler && !res.headersSent) {
       try {
         this.options.errorHandler(error, req, res);
       } catch (handlerError) {
@@ -116,7 +102,7 @@ export class AngularSSRMiddleware implements NestMiddleware {
       }
     }
 
-    if (!this.responseAlreadySent(res)) {
+    if (!res.headersSent) {
       next(error);
     }
   }

--- a/lib/angular-ssr.middleware.ts
+++ b/lib/angular-ssr.middleware.ts
@@ -1,58 +1,122 @@
-import { Inject, Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
 import { AngularSSRService } from './angular-ssr.service';
+import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
-import type { AngularSSRModuleOptions } from './interfaces';
+import type { AngularSSRModuleOptions, SkipPath } from './interfaces';
 import type { NextFunction, Request, Response } from 'express';
+
+const DEFAULT_SKIP_PATHS: SkipPath[] = ['/api'];
+
+const STATIC_FILE_EXTENSIONS = [
+  '.js',
+  '.css',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
+  '.map',
+  '.json',
+  '.webp',
+  '.avif',
+  '.mp4',
+  '.webm',
+  '.mp3',
+  '.wav',
+  '.pdf',
+];
 
 @Injectable()
 export class AngularSSRMiddleware implements NestMiddleware {
-  private readonly logger = new Logger(AngularSSRMiddleware.name);
+  private readonly logger = new DebugLogger(AngularSSRMiddleware.name);
 
   constructor(
+    @Inject(AngularSSRService)
     private readonly ssrService: AngularSSRService,
     @Inject(ANGULAR_SSR_OPTIONS)
     private readonly options: AngularSSRModuleOptions,
   ) {}
 
   async use(req: Request, res: Response, next: NextFunction): Promise<void> {
-    // Skip if already handled or if requesting static assets
-    if (res.headersSent) {
-      next();
-      return;
-    }
-
-    // Skip static file requests (common extensions)
     const url = req.originalUrl || req.url;
-    if (this.isStaticFileRequest(url)) {
+    const bypass = this.bypassReason(req, res, url);
+    if (bypass) {
+      this.logger.debug(`bypass ${req.method} ${url}: ${bypass}`);
       next();
       return;
     }
 
-    // Skip API routes (customize as needed)
-    if (url.startsWith('/api')) {
-      next();
-      return;
-    }
+    this.logger.debug(`render ${req.method} ${url}`);
 
     try {
       const html = await this.ssrService.render(req, res);
 
+      // The configured errorHandler may have written a response from inside
+      // service.render(); never double-respond.
+      if (this.responseAlreadySent(res)) {
+        this.logger.debug(`response already sent by service for ${url}`);
+        return;
+      }
+
       if (html === null) {
-        // No response from Angular, pass to next handler
+        this.logger.debug(`null render result for ${url}, deferring to next()`);
         next();
         return;
       }
 
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.send(html);
+      this.logger.debug(`sent ${String(html.length)} bytes for ${url}`);
     } catch (error) {
-      this.logger.error('SSR rendering error', error);
+      this.handleRenderError(error as Error, req, res, next);
+    }
+  }
 
-      // If error handler is set and was called, don't continue
-      if (this.options.errorHandler) {
-        return;
+  private bypassReason(req: Request, res: Response, url: string): string | null {
+    if (this.responseAlreadySent(res)) {
+      return 'response headers already sent';
+    }
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return `method ${req.method} not GET/HEAD`;
+    }
+    if (this.isStaticFileRequest(url)) {
+      return 'static file extension';
+    }
+    if (this.isSkippedPath(url)) {
+      return 'matches skipPaths';
+    }
+    return null;
+  }
+
+  /**
+   * Read `res.headersSent` through a structural cast so the linter doesn't
+   * narrow it to a constant after the first early-return check — the value
+   * mutates whenever the user errorHandler writes to the response.
+   */
+  private responseAlreadySent(res: Response): boolean {
+    return (res as { headersSent: boolean }).headersSent;
+  }
+
+  private handleRenderError(error: Error, req: Request, res: Response, next: NextFunction): void {
+    this.logger.error('SSR rendering error', error);
+
+    // Errors thrown before the service's inner try/catch (e.g. engine not
+    // initialized) bypass the user's errorHandler. Invoke it here as a
+    // safety net so the request never silently hangs.
+    if (this.options.errorHandler && !this.responseAlreadySent(res)) {
+      try {
+        this.options.errorHandler(error, req, res);
+      } catch (handlerError) {
+        this.logger.error('Error handler threw', handlerError);
       }
+    }
 
+    if (!this.responseAlreadySent(res)) {
       next(error);
     }
   }
@@ -61,31 +125,14 @@ export class AngularSSRMiddleware implements NestMiddleware {
    * Check if the request is for a static file
    */
   private isStaticFileRequest(url: string): boolean {
-    const staticExtensions = [
-      '.js',
-      '.css',
-      '.png',
-      '.jpg',
-      '.jpeg',
-      '.gif',
-      '.svg',
-      '.ico',
-      '.woff',
-      '.woff2',
-      '.ttf',
-      '.eot',
-      '.map',
-      '.json',
-      '.webp',
-      '.avif',
-      '.mp4',
-      '.webm',
-      '.mp3',
-      '.wav',
-      '.pdf',
-    ];
-
     const urlPath = url.split('?')[0].toLowerCase();
-    return staticExtensions.some((ext) => urlPath.endsWith(ext));
+    return STATIC_FILE_EXTENSIONS.some((ext) => urlPath.endsWith(ext));
+  }
+
+  private isSkippedPath(url: string): boolean {
+    const skipPaths = this.options.skipPaths ?? DEFAULT_SKIP_PATHS;
+    return skipPaths.some((rule) =>
+      typeof rule === 'string' ? url.startsWith(rule) : rule.test(url),
+    );
   }
 }

--- a/lib/angular-ssr.module.spec.ts
+++ b/lib/angular-ssr.module.spec.ts
@@ -182,17 +182,17 @@ describe('AngularSSRModule', () => {
       expect(mockConsumer.apply).toHaveBeenCalled();
     });
 
-    it('uses (.*) as the default render path', () => {
+    it('uses the splat wildcard as the default render path', () => {
       const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-      expect(applyResult.forRoutes).toHaveBeenCalledWith('(.*)');
+      expect(applyResult.forRoutes).toHaveBeenCalledWith('{/*splat}');
     });
 
-    it('uses (.*) for both static and SSR routes by default', () => {
+    it('uses the splat wildcard for both static and SSR routes by default', () => {
       const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '(.*)');
-      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '(.*)');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '{/*splat}');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '{/*splat}');
     });
 
     it('honours a custom render path string', () => {

--- a/lib/angular-ssr.module.spec.ts
+++ b/lib/angular-ssr.module.spec.ts
@@ -17,8 +17,6 @@ describe('AngularSSRModule', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    // Reset the static options
-    (AngularSSRModule as any).options = undefined;
   });
 
   describe('forRoot()', () => {
@@ -34,10 +32,13 @@ describe('AngularSSRModule', () => {
     it('should include options provider', () => {
       const result = AngularSSRModule.forRoot(mockOptions);
 
-      const optionsProvider = result.providers?.find((p: any) => p.provide === ANGULAR_SSR_OPTIONS);
+      const optionsProvider = result.providers?.find(
+        (p): p is { provide: symbol; useValue: AngularSSRModuleOptions } =>
+          (p as { provide?: symbol }).provide === ANGULAR_SSR_OPTIONS,
+      );
 
       expect(optionsProvider).toBeDefined();
-      expect((optionsProvider as any).useValue).toBe(mockOptions);
+      expect(optionsProvider?.useValue).toBe(mockOptions);
     });
 
     it('should include AngularSSRService provider', () => {
@@ -80,11 +81,19 @@ describe('AngularSSRModule', () => {
 
       const result = AngularSSRModule.forRootAsync(asyncOptions);
 
-      const optionsProvider = result.providers?.find((p: any) => p.provide === ANGULAR_SSR_OPTIONS);
+      const optionsProvider = result.providers?.find(
+        (
+          p,
+        ): p is {
+          provide: symbol;
+          useFactory: (...args: unknown[]) => unknown;
+          inject: unknown[];
+        } => (p as { provide?: symbol }).provide === ANGULAR_SSR_OPTIONS,
+      );
 
       expect(optionsProvider).toBeDefined();
-      expect((optionsProvider as any).useFactory).toBeDefined();
-      expect((optionsProvider as any).inject).toEqual(['SomeDependency']);
+      expect(optionsProvider?.useFactory).toBeTypeOf('function');
+      expect(optionsProvider?.inject).toEqual(['SomeDependency']);
     });
 
     it('should include imports from async options', () => {
@@ -107,9 +116,17 @@ describe('AngularSSRModule', () => {
 
       const result = AngularSSRModule.forRootAsync(asyncOptions);
 
-      const optionsProvider = result.providers?.find((p: any) => p.provide === ANGULAR_SSR_OPTIONS);
+      const optionsProvider = result.providers?.find(
+        (
+          p,
+        ): p is {
+          provide: symbol;
+          useFactory: (...args: unknown[]) => unknown;
+          inject: unknown[];
+        } => (p as { provide?: symbol }).provide === ANGULAR_SSR_OPTIONS,
+      );
 
-      expect((optionsProvider as any).inject).toEqual([]);
+      expect(optionsProvider?.inject).toEqual([]);
     });
 
     it('should use empty array for imports when not provided', () => {
@@ -122,7 +139,7 @@ describe('AngularSSRModule', () => {
       expect(result.imports).toEqual([]);
     });
 
-    it('should call factory and store resolved options', async () => {
+    it('should call factory and return its resolved options', async () => {
       const factory = vi.fn().mockResolvedValue(mockOptions);
       const asyncOptions: AngularSSRModuleAsyncOptions = {
         useFactory: factory,
@@ -130,23 +147,27 @@ describe('AngularSSRModule', () => {
 
       const result = AngularSSRModule.forRootAsync(asyncOptions);
 
-      const optionsProvider = result.providers?.find((p: any) => p.provide === ANGULAR_SSR_OPTIONS);
+      const optionsProvider = result.providers?.find(
+        (
+          p,
+        ): p is {
+          provide: symbol;
+          useFactory: (...args: unknown[]) => Promise<unknown>;
+        } => (p as { provide?: symbol }).provide === ANGULAR_SSR_OPTIONS,
+      );
 
-      // Call the factory
-      const resolvedOptions = await (optionsProvider as any).useFactory();
-
+      expect(optionsProvider).toBeDefined();
+      const resolved = await optionsProvider?.useFactory();
       expect(factory).toHaveBeenCalled();
-      expect(resolvedOptions).toBe(mockOptions);
+      expect(resolved).toBe(mockOptions);
     });
   });
 
   describe('configure()', () => {
-    let module: AngularSSRModule;
     let mockConsumer: MiddlewareConsumer;
     let applyResult: { forRoutes: ReturnType<typeof vi.fn> };
 
     beforeEach(() => {
-      module = new AngularSSRModule();
       applyResult = {
         forRoutes: vi.fn().mockReturnThis(),
       };
@@ -155,63 +176,47 @@ describe('AngularSSRModule', () => {
       } as unknown as MiddlewareConsumer;
     });
 
-    it('should throw error if options not configured', () => {
-      expect(() => module.configure(mockConsumer)).toThrow(
-        'AngularSSRModule options not configured. Use forRoot() or forRootAsync().',
-      );
-    });
-
-    it('should apply static file middleware', () => {
-      AngularSSRModule.forRoot(mockOptions);
-
+    it('applies the static file middleware', () => {
+      const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-
       expect(mockConsumer.apply).toHaveBeenCalled();
     });
 
-    it('should use default render path "*" when not specified', () => {
-      AngularSSRModule.forRoot(mockOptions);
-
+    it('uses (.*) as the default render path', () => {
+      const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-
-      // Should be called for static files and SSR
-      expect(applyResult.forRoutes).toHaveBeenCalledWith('*');
+      expect(applyResult.forRoutes).toHaveBeenCalledWith('(.*)');
     });
 
-    it('should use custom render path when specified as string', () => {
-      const optionsWithPath: AngularSSRModuleOptions = {
-        ...mockOptions,
-        renderPath: '/app/*',
-      };
-      AngularSSRModule.forRoot(optionsWithPath);
-
+    it('uses (.*) for both static and SSR routes by default', () => {
+      const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-
-      expect(applyResult.forRoutes).toHaveBeenCalledWith('/app/*');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '(.*)');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '(.*)');
     });
 
-    it('should use custom render paths when specified as array', () => {
-      const optionsWithPaths: AngularSSRModuleOptions = {
+    it('honours a custom render path string', () => {
+      const module = new AngularSSRModule({ ...mockOptions, renderPath: '/app/*splat' });
+      module.configure(mockConsumer);
+      expect(applyResult.forRoutes).toHaveBeenCalledWith('/app/*splat');
+    });
+
+    it('honours custom render paths as an array', () => {
+      const module = new AngularSSRModule({
         ...mockOptions,
         renderPath: ['/app', '/dashboard'],
-      };
-      AngularSSRModule.forRoot(optionsWithPaths);
-
+      });
       module.configure(mockConsumer);
-
       expect(applyResult.forRoutes).toHaveBeenCalledWith('/app', '/dashboard');
     });
 
-    it('should use custom static path when specified', () => {
-      const optionsWithStaticPath: AngularSSRModuleOptions = {
+    it('honours a custom static path', () => {
+      const module = new AngularSSRModule({
         ...mockOptions,
-        rootStaticPath: '/static/*',
-      };
-      AngularSSRModule.forRoot(optionsWithStaticPath);
-
+        rootStaticPath: '/static/*splat',
+      });
       module.configure(mockConsumer);
-
-      expect(applyResult.forRoutes).toHaveBeenCalledWith('/static/*');
+      expect(applyResult.forRoutes).toHaveBeenCalledWith('/static/*splat');
     });
   });
 });

--- a/lib/angular-ssr.module.ts
+++ b/lib/angular-ssr.module.ts
@@ -14,16 +14,10 @@ import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type { AngularSSRModuleAsyncOptions, AngularSSRModuleOptions } from './interfaces';
 
-/**
- * Default wildcard route. Uses `(.*)` regex syntax which:
- *   - matches the root `/` and every nested path,
- *   - is accepted by both NestJS 10 (path-to-regexp 6) and NestJS 11
- *     (path-to-regexp 8 / Express 5).
- *
- * Override `renderPath` / `rootStaticPath` if you want a tighter mount point
- * (e.g. `'/{*splat}'` on NestJS 11, `'*'` on NestJS 10).
- */
-const DEFAULT_WILDCARD = '(.*)';
+// '{/*splat}' is the NestJS 11 / Express 5 / path-to-regexp v8 splat
+// syntax that matches both '/' and every nested path. Override via
+// renderPath / rootStaticPath for a tighter mount point.
+const DEFAULT_WILDCARD = '{/*splat}';
 
 @Global()
 @Module({})

--- a/lib/angular-ssr.module.ts
+++ b/lib/angular-ssr.module.ts
@@ -1,28 +1,44 @@
 import {
   DynamicModule,
   Global,
+  Inject,
   MiddlewareConsumer,
   Module,
   NestModule,
   Provider,
 } from '@nestjs/common';
-import * as express from 'express';
+import express from 'express';
 import { AngularSSRMiddleware } from './angular-ssr.middleware';
 import { AngularSSRService } from './angular-ssr.service';
+import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type { AngularSSRModuleAsyncOptions, AngularSSRModuleOptions } from './interfaces';
+
+/**
+ * Default wildcard route. Uses `(.*)` regex syntax which:
+ *   - matches the root `/` and every nested path,
+ *   - is accepted by both NestJS 10 (path-to-regexp 6) and NestJS 11
+ *     (path-to-regexp 8 / Express 5).
+ *
+ * Override `renderPath` / `rootStaticPath` if you want a tighter mount point
+ * (e.g. `'/{*splat}'` on NestJS 11, `'*'` on NestJS 10).
+ */
+const DEFAULT_WILDCARD = '(.*)';
 
 @Global()
 @Module({})
 export class AngularSSRModule implements NestModule {
-  private static options: AngularSSRModuleOptions | undefined;
+  private readonly logger = new DebugLogger(AngularSSRModule.name);
+
+  constructor(
+    @Inject(ANGULAR_SSR_OPTIONS)
+    private readonly options: AngularSSRModuleOptions,
+  ) {}
 
   /**
    * Configure the module with static options
    */
   static forRoot(options: AngularSSRModuleOptions): DynamicModule {
-    AngularSSRModule.options = options;
-
     const optionsProvider: Provider = {
       provide: ANGULAR_SSR_OPTIONS,
       useValue: options,
@@ -30,7 +46,7 @@ export class AngularSSRModule implements NestModule {
 
     return {
       module: AngularSSRModule,
-      providers: [optionsProvider, AngularSSRService],
+      providers: [optionsProvider, AngularSSRService, AngularSSRMiddleware],
       exports: [AngularSSRService, ANGULAR_SSR_OPTIONS],
     };
   }
@@ -41,60 +57,46 @@ export class AngularSSRModule implements NestModule {
   static forRootAsync(options: AngularSSRModuleAsyncOptions): DynamicModule {
     const asyncOptionsProvider: Provider = {
       provide: ANGULAR_SSR_OPTIONS,
-      useFactory: async (...args: unknown[]) => {
-        const resolvedOptions = await options.useFactory(...args);
-        AngularSSRModule.options = resolvedOptions;
-        return resolvedOptions;
-      },
+      useFactory: async (...args: unknown[]) => await options.useFactory(...args),
       inject: options.inject ?? [],
     };
 
     return {
       module: AngularSSRModule,
       imports: options.imports ?? [],
-      providers: [asyncOptionsProvider, AngularSSRService],
+      providers: [asyncOptionsProvider, AngularSSRService, AngularSSRMiddleware],
       exports: [AngularSSRService, ANGULAR_SSR_OPTIONS],
     };
   }
 
   configure(consumer: MiddlewareConsumer): void {
-    const options = AngularSSRModule.options;
+    const renderPaths = this.getRenderPaths(this.options);
+    const staticPath =
+      typeof this.options.rootStaticPath === 'string'
+        ? this.options.rootStaticPath
+        : DEFAULT_WILDCARD;
 
-    if (!options) {
-      throw new Error('AngularSSRModule options not configured. Use forRoot() or forRootAsync().');
-    }
-
-    // Determine render paths
-    const renderPaths = this.getRenderPaths(options);
-
-    // Serve static files from the browser distribution folder
-    const staticPath = typeof options.rootStaticPath === 'string' ? options.rootStaticPath : '*';
+    this.logger.debug(`configure() staticPath=${staticPath} renderPaths=${renderPaths.join(',')}`);
 
     consumer
       .apply(
-        express.static(options.browserDistFolder, {
+        express.static(this.options.browserDistFolder, {
           maxAge: '1y',
           index: false, // Don't serve index.html for directory requests
         }),
       )
       .forRoutes(staticPath);
 
-    // Apply SSR middleware for render paths
     consumer.apply(AngularSSRMiddleware).forRoutes(...renderPaths);
   }
 
-  /**
-   * Get the render paths from options
-   */
   private getRenderPaths(options: AngularSSRModuleOptions): string[] {
     if (!options.renderPath) {
-      return ['*'];
+      return [DEFAULT_WILDCARD];
     }
-
     if (Array.isArray(options.renderPath)) {
       return options.renderPath;
     }
-
     return [options.renderPath];
   }
 }

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -1,16 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularSSRService, DEFAULT_CACHE_EXPIRATION_TIME } from './angular-ssr.service';
+import { REQUEST, RESPONSE } from './tokens';
 import type { AngularSSRModuleOptions, CacheStorage } from './interfaces';
 import type { Request, Response } from 'express';
 
-// Mock AngularAppEngine
-const createMockAngularApp = () => ({
+// Engine factories — each shapes the duck-type so the service routes to the
+// expected branch without needing access to the real Angular SSR classes.
+
+const createAppEngine = () => ({
+  // No render method; constructor.name is 'Object' — falls through to the
+  // AngularAppEngine branch.
   handle: vi.fn(),
 });
 
-// Mock Request
+const createNodeAppEngine = () => {
+  class AngularNodeAppEngine {
+    handle = vi.fn();
+  }
+  return new AngularNodeAppEngine();
+};
+
+const createCommonEngine = () => ({
+  // CommonEngine has render() but not handle().
+  render: vi.fn(),
+});
+
 const createMockRequest = (overrides: Partial<Request> = {}): Request =>
   ({
+    method: 'GET',
     protocol: 'http',
     get: vi.fn((header: string) => {
       if (header === 'host') {
@@ -20,7 +37,6 @@ const createMockRequest = (overrides: Partial<Request> = {}): Request =>
     hostname: 'localhost',
     originalUrl: '/test-page',
     url: '/test-page',
-    method: 'GET',
     headers: {
       'user-agent': 'test-agent',
       accept: 'text/html',
@@ -28,7 +44,6 @@ const createMockRequest = (overrides: Partial<Request> = {}): Request =>
     ...overrides,
   }) as unknown as Request;
 
-// Mock Response
 const createMockResponse = (): Response =>
   ({
     setHeader: vi.fn(),
@@ -38,15 +53,13 @@ const createMockResponse = (): Response =>
 
 describe('AngularSSRService', () => {
   let service: AngularSSRService;
-  let mockAngularApp: ReturnType<typeof createMockAngularApp>;
   let mockOptions: AngularSSRModuleOptions;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    mockAngularApp = createMockAngularApp();
     mockOptions = {
       browserDistFolder: '/dist/browser',
-      bootstrap: vi.fn().mockResolvedValue(mockAngularApp),
+      bootstrap: vi.fn().mockResolvedValue(createAppEngine()),
     };
   });
 
@@ -58,25 +71,16 @@ describe('AngularSSRService', () => {
   describe('constructor', () => {
     it('should initialize with default cache settings when cache is undefined', () => {
       service = new AngularSSRService(mockOptions);
-      // Service should be created successfully
       expect(service).toBeDefined();
     });
 
     it('should initialize with cache disabled when cache is false', () => {
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: false,
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: false });
       expect(service).toBeDefined();
     });
 
     it('should initialize with default cache when cache is true', () => {
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: true,
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: true });
       expect(service).toBeDefined();
     });
 
@@ -89,14 +93,10 @@ describe('AngularSSRService', () => {
         has: vi.fn(),
       };
 
-      const options: AngularSSRModuleOptions = {
+      service = new AngularSSRService({
         ...mockOptions,
-        cache: {
-          storage: customStorage,
-          expiresIn: 120_000,
-        },
-      };
-      service = new AngularSSRService(options);
+        cache: { storage: customStorage, expiresIn: 120_000 },
+      });
       expect(service).toBeDefined();
     });
   });
@@ -110,158 +110,59 @@ describe('AngularSSRService', () => {
     });
 
     it('should throw error if bootstrap fails', async () => {
-      const error = new Error('Bootstrap failed');
-      mockOptions.bootstrap = vi.fn().mockRejectedValue(error);
+      mockOptions.bootstrap = vi.fn().mockRejectedValue(new Error('Bootstrap failed'));
       service = new AngularSSRService(mockOptions);
 
       await expect(service.onModuleInit()).rejects.toThrow('Bootstrap failed');
     });
   });
 
-  describe('render()', () => {
+  describe('render() — AngularAppEngine path (default fallback)', () => {
+    let engine: ReturnType<typeof createAppEngine>;
+
     beforeEach(async () => {
+      engine = createAppEngine();
+      mockOptions.bootstrap = vi.fn().mockResolvedValue(engine);
       service = new AngularSSRService(mockOptions);
       await service.onModuleInit();
     });
 
     it('should throw error if Angular app is not initialized', async () => {
-      const uninitializedService = new AngularSSRService(mockOptions);
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      await expect(uninitializedService.render(request, response)).rejects.toThrow(
+      const uninitialized = new AngularSSRService(mockOptions);
+      await expect(uninitialized.render(createMockRequest(), createMockResponse())).rejects.toThrow(
         'Angular SSR engine not initialized',
       );
     });
 
     it('should render Angular app and return HTML', async () => {
       const mockHtml = '<html><body>Test</body></html>';
-      const mockAngularResponse = {
-        text: vi.fn().mockResolvedValue(mockHtml),
-      };
-      mockAngularApp.handle.mockResolvedValue(mockAngularResponse);
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue(mockHtml) });
 
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      const result = await service.render(request, response);
+      const result = await service.render(createMockRequest(), createMockResponse());
 
       expect(result).toBe(mockHtml);
-      expect(mockAngularApp.handle).toHaveBeenCalled();
+      expect(engine.handle).toHaveBeenCalled();
     });
 
     it('should return null if Angular app returns no response', async () => {
-      mockAngularApp.handle.mockResolvedValue(null);
-
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      const result = await service.render(request, response);
-
+      engine.handle.mockResolvedValue(null);
+      const result = await service.render(createMockRequest(), createMockResponse());
       expect(result).toBeNull();
-    });
-
-    it('should cache rendered HTML', async () => {
-      const mockHtml = '<html><body>Cached</body></html>';
-      const mockAngularResponse = {
-        text: vi.fn().mockResolvedValue(mockHtml),
-      };
-      mockAngularApp.handle.mockResolvedValue(mockAngularResponse);
-
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      // First render - should call Angular
-      await service.render(request, response);
-      expect(mockAngularApp.handle).toHaveBeenCalledTimes(1);
-
-      // Second render - should use cache
-      const result = await service.render(request, response);
-      expect(result).toBe(mockHtml);
-      expect(mockAngularApp.handle).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not use cache when disabled', async () => {
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: false,
-      };
-      service = new AngularSSRService(options);
-      await service.onModuleInit();
-
-      const mockHtml = '<html><body>Not Cached</body></html>';
-      const mockAngularResponse = {
-        text: vi.fn().mockResolvedValue(mockHtml),
-      };
-      mockAngularApp.handle.mockResolvedValue(mockAngularResponse);
-
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      // First render
-      await service.render(request, response);
-      expect(mockAngularApp.handle).toHaveBeenCalledTimes(1);
-
-      // Second render - should call Angular again since cache is disabled
-      await service.render(request, response);
-      expect(mockAngularApp.handle).toHaveBeenCalledTimes(2);
-    });
-
-    it('should call error handler on render error', async () => {
-      const error = new Error('Render failed');
-      mockAngularApp.handle.mockRejectedValue(error);
-
-      const errorHandler = vi.fn();
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        errorHandler,
-      };
-      service = new AngularSSRService(options);
-      await service.onModuleInit();
-
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      const result = await service.render(request, response);
-
-      expect(errorHandler).toHaveBeenCalledWith(error, request, response);
-      expect(result).toBeNull();
-    });
-
-    it('should throw error if no error handler and render fails', async () => {
-      const error = new Error('Render failed');
-      mockAngularApp.handle.mockRejectedValue(error);
-
-      const request = createMockRequest();
-      const response = createMockResponse();
-
-      await expect(service.render(request, response)).rejects.toThrow('Render failed');
     });
 
     it('should handle requests with different protocols', async () => {
       const mockHtml = '<html><body>HTTPS</body></html>';
-      const mockAngularResponse = {
-        text: vi.fn().mockResolvedValue(mockHtml),
-      };
-      mockAngularApp.handle.mockResolvedValue(mockAngularResponse);
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue(mockHtml) });
 
-      const request = createMockRequest({ protocol: 'https' });
-      const response = createMockResponse();
+      await service.render(createMockRequest({ protocol: 'https' }), createMockResponse());
 
-      const result = await service.render(request, response);
-
-      expect(result).toBe(mockHtml);
-      // Verify the request was created with https protocol
-      const handleCall = mockAngularApp.handle.mock.calls[0][0] as globalThis.Request;
-      expect(handleCall.url).toContain('https://');
+      const fetchRequest = engine.handle.mock.calls[0][0] as globalThis.Request;
+      expect(fetchRequest.url).toContain('https://');
     });
 
     it('should handle requests with multiple header values', async () => {
       const mockHtml = '<html><body>Test</body></html>';
-      const mockAngularResponse = {
-        text: vi.fn().mockResolvedValue(mockHtml),
-      };
-      mockAngularApp.handle.mockResolvedValue(mockAngularResponse);
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue(mockHtml) });
 
       const request = createMockRequest({
         headers: {
@@ -269,11 +170,339 @@ describe('AngularSSRService', () => {
           'user-agent': 'test',
         },
       } as unknown as Partial<Request>);
+
+      const result = await service.render(request, createMockResponse());
+      expect(result).toBe(mockHtml);
+    });
+
+    it('passes the response into the engine via requestContext', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      expect(engine.handle.mock.calls[0][1]).toEqual({ response });
+    });
+
+    it('falls back to localhost when the host header is missing', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const request = createMockRequest({
+        get: vi.fn(),
+      } as unknown as Partial<Request>);
+      await service.render(request, createMockResponse());
+
+      const fetchRequest = engine.handle.mock.calls[0][0] as { url: string };
+      expect(fetchRequest.url).toContain('http://localhost/');
+    });
+
+    it('falls back to "/" when neither originalUrl nor url is set', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const request = createMockRequest({
+        originalUrl: undefined,
+        url: undefined,
+      } as unknown as Partial<Request>);
+      await service.render(request, createMockResponse());
+
+      const fetchRequest = engine.handle.mock.calls[0][0] as { url: string };
+      expect(fetchRequest.url).toBe('http://localhost:3000/');
+    });
+
+    it('skips header entries whose value is undefined', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const request = createMockRequest({
+        headers: {
+          accept: 'text/html',
+          'x-empty': undefined,
+        },
+      } as unknown as Partial<Request>);
+      await service.render(request, createMockResponse());
+
+      const fetchRequest = engine.handle.mock.calls[0][0] as { headers: Headers };
+      expect(fetchRequest.headers.has('accept')).toBe(true);
+      expect(fetchRequest.headers.has('x-empty')).toBe(false);
+    });
+  });
+
+  describe('render() — AngularNodeAppEngine path', () => {
+    let engine: { handle: ReturnType<typeof vi.fn> };
+
+    beforeEach(async () => {
+      engine = createNodeAppEngine();
+      mockOptions.bootstrap = vi.fn().mockResolvedValue(engine);
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+    });
+
+    it('passes the Express request directly into the engine', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+      await service.render(request, response);
+
+      // For Node engine, the FIRST arg is the Express request itself, not a
+      // Web fetch Request — that's the entire point of this branch.
+      expect(engine.handle).toHaveBeenCalledWith(request, { response });
+    });
+
+    it('returns null when handle resolves to null', async () => {
+      engine.handle.mockResolvedValue(null);
+      const result = await service.render(createMockRequest(), createMockResponse());
+      expect(result).toBeNull();
+    });
+
+    it('honours an explicit engineType override even when ducktype would mismatch', async () => {
+      const ducklessEngine = { handle: vi.fn() };
+      ducklessEngine.handle.mockResolvedValue({
+        text: vi.fn().mockResolvedValue('<html>node</html>'),
+      });
+      mockOptions.bootstrap = vi.fn().mockResolvedValue(ducklessEngine);
+      const overridden = new AngularSSRService({ ...mockOptions, engineType: 'node-app' });
+      await overridden.onModuleInit();
+
+      const request = createMockRequest();
+      await overridden.render(request, createMockResponse());
+
+      expect(ducklessEngine.handle).toHaveBeenCalledWith(request, expect.any(Object));
+    });
+  });
+
+  describe('render() — CommonEngine path', () => {
+    let engine: ReturnType<typeof createCommonEngine>;
+
+    beforeEach(async () => {
+      engine = createCommonEngine();
+      mockOptions = {
+        ...mockOptions,
+        bootstrap: vi.fn().mockResolvedValue(engine),
+        angularBootstrap: vi.fn().mockResolvedValue('bootstrap-fn'),
+      };
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+    });
+
+    it('routes to render() based on duck-type detection', async () => {
+      engine.render.mockResolvedValue('<html>common</html>');
+      const result = await service.render(createMockRequest(), createMockResponse());
+
+      expect(engine.render).toHaveBeenCalled();
+      expect(result).toBe('<html>common</html>');
+    });
+
+    it('passes documentFilePath, publicPath, url, and bootstrap', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      await service.render(createMockRequest(), createMockResponse());
+
+      const opts = engine.render.mock.calls[0][0];
+      expect(opts.documentFilePath).toBe('/dist/browser/index.server.html');
+      expect(opts.publicPath).toBe('/dist/browser');
+      expect(opts.url).toContain('http://localhost:3000/test-page');
+      expect(opts.bootstrap).toBe('bootstrap-fn');
+    });
+
+    it('honours a custom indexHtml path', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      const customService = new AngularSSRService({
+        ...mockOptions,
+        indexHtml: '/custom/index.html',
+      });
+      await customService.onModuleInit();
+      await customService.render(createMockRequest(), createMockResponse());
+
+      expect(engine.render.mock.calls.at(-1)?.[0].documentFilePath).toBe('/custom/index.html');
+    });
+
+    it('injects per-request REQUEST and RESPONSE providers', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      const request = createMockRequest();
+      const response = createMockResponse();
+      await service.render(request, response);
+
+      const providers = engine.render.mock.calls[0][0].providers;
+      expect(providers).toEqual(
+        expect.arrayContaining([
+          { provide: REQUEST, useValue: request },
+          { provide: RESPONSE, useValue: response },
+        ]),
+      );
+    });
+
+    it('preserves user-supplied extraProviders alongside REQUEST/RESPONSE', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      const extraProvider = { provide: 'CUSTOM', useValue: 42 };
+      const customService = new AngularSSRService({
+        ...mockOptions,
+        extraProviders: [extraProvider],
+      });
+      await customService.onModuleInit();
+      await customService.render(createMockRequest(), createMockResponse());
+
+      const providers = engine.render.mock.calls.at(-1)?.[0].providers;
+      expect(providers).toEqual(
+        expect.arrayContaining([
+          extraProvider,
+          expect.objectContaining({ provide: REQUEST }),
+          expect.objectContaining({ provide: RESPONSE }),
+        ]),
+      );
+    });
+
+    it('passes inlineCriticalCss through (defaults to true)', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      await service.render(createMockRequest(), createMockResponse());
+      expect(engine.render.mock.calls[0][0].inlineCriticalCss).toBe(true);
+    });
+
+    it('honours an explicit inlineCriticalCss=false', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      const customService = new AngularSSRService({
+        ...mockOptions,
+        inlineCriticalCss: false,
+      });
+      await customService.onModuleInit();
+      await customService.render(createMockRequest(), createMockResponse());
+
+      expect(engine.render.mock.calls.at(-1)?.[0].inlineCriticalCss).toBe(false);
+    });
+
+    it('runs without angularBootstrap when not provided', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      const customService = new AngularSSRService({
+        ...mockOptions,
+        angularBootstrap: undefined,
+      });
+      await customService.onModuleInit();
+      await customService.render(createMockRequest(), createMockResponse());
+
+      expect(engine.render.mock.calls.at(-1)?.[0].bootstrap).toBeUndefined();
+    });
+  });
+
+  describe('render() — engineType override', () => {
+    it('forces CommonEngine path when engineType=common', async () => {
+      const commonish = { render: vi.fn().mockResolvedValue('<html>forced</html>') };
+      mockOptions = {
+        ...mockOptions,
+        bootstrap: vi.fn().mockResolvedValue(commonish),
+        engineType: 'common',
+      };
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+
+      const result = await service.render(createMockRequest(), createMockResponse());
+      expect(commonish.render).toHaveBeenCalled();
+      expect(result).toBe('<html>forced</html>');
+    });
+
+    it('forces AngularAppEngine path when engineType=app', async () => {
+      const ambiguous = {
+        render: vi.fn(),
+        handle: vi.fn().mockResolvedValue({ text: vi.fn().mockResolvedValue('<html>app</html>') }),
+      };
+      mockOptions = {
+        ...mockOptions,
+        bootstrap: vi.fn().mockResolvedValue(ambiguous),
+        engineType: 'app',
+      };
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+
+      const result = await service.render(createMockRequest(), createMockResponse());
+
+      expect(ambiguous.render).not.toHaveBeenCalled();
+      // For app engine, first arg is a Web fetch Request, not the Express one;
+      // it has a string `url` and a Headers instance.
+      const firstArg = ambiguous.handle.mock.calls[0][0] as {
+        url: string;
+        headers: Headers;
+      };
+      expect(typeof firstArg.url).toBe('string');
+      expect(firstArg.headers).toBeInstanceOf(Headers);
+      expect(result).toBe('<html>app</html>');
+    });
+  });
+
+  describe('caching', () => {
+    let engine: ReturnType<typeof createAppEngine>;
+
+    beforeEach(async () => {
+      engine = createAppEngine();
+      mockOptions = { ...mockOptions, bootstrap: vi.fn().mockResolvedValue(engine) };
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+    });
+
+    it('should cache GET responses', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+      const request = createMockRequest();
       const response = createMockResponse();
 
+      await service.render(request, response);
+      await service.render(request, response);
+
+      expect(engine.handle).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache when cache is disabled', async () => {
+      const noCache = new AngularSSRService({ ...mockOptions, cache: false });
+      await noCache.onModuleInit();
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+      await noCache.render(request, response);
+      await noCache.render(request, response);
+
+      expect(engine.handle).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache POST responses', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+      const post = createMockRequest({ method: 'POST' });
+      const response = createMockResponse();
+
+      await service.render(post, response);
+      await service.render(post, response);
+
+      expect(engine.handle).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    let engine: ReturnType<typeof createAppEngine>;
+
+    beforeEach(async () => {
+      engine = createAppEngine();
+      mockOptions = { ...mockOptions, bootstrap: vi.fn().mockResolvedValue(engine) };
+    });
+
+    it('should call error handler on render error', async () => {
+      const error = new Error('Render failed');
+      engine.handle.mockRejectedValue(error);
+
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({ ...mockOptions, errorHandler });
+      await service.onModuleInit();
+
+      const request = createMockRequest();
+      const response = createMockResponse();
       const result = await service.render(request, response);
 
-      expect(result).toBe(mockHtml);
+      expect(errorHandler).toHaveBeenCalledWith(error, request, response);
+      expect(result).toBeNull();
+    });
+
+    it('should throw error if no error handler and render fails', async () => {
+      engine.handle.mockRejectedValue(new Error('Render failed'));
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+
+      await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(
+        'Render failed',
+      );
     });
   });
 
@@ -287,27 +516,17 @@ describe('AngularSSRService', () => {
         has: vi.fn(),
       };
 
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: { storage: customStorage },
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: { storage: customStorage } });
       await service.onModuleInit();
-
       await service.clearCache();
 
       expect(customStorage.clear).toHaveBeenCalled();
     });
 
     it('should do nothing when cache is disabled', async () => {
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: false,
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: false });
       await service.onModuleInit();
 
-      // Should not throw
       await expect(service.clearCache()).resolves.toBeUndefined();
     });
   });
@@ -322,29 +541,19 @@ describe('AngularSSRService', () => {
         has: vi.fn(),
       };
 
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: { storage: customStorage },
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: { storage: customStorage } });
       await service.onModuleInit();
 
       const result = await service.invalidateCache('test-key');
-
       expect(customStorage.delete).toHaveBeenCalledWith('test-key');
       expect(result).toBe(true);
     });
 
     it('should return false when cache is disabled', async () => {
-      const options: AngularSSRModuleOptions = {
-        ...mockOptions,
-        cache: false,
-      };
-      service = new AngularSSRService(options);
+      service = new AngularSSRService({ ...mockOptions, cache: false });
       await service.onModuleInit();
 
       const result = await service.invalidateCache('test-key');
-
       expect(result).toBe(false);
     });
   });

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -129,6 +129,21 @@ describe('AngularSSRService', () => {
 
       await expect(service.onModuleInit()).rejects.toThrow('Bootstrap failed');
     });
+
+    it('throws a descriptive error when bootstrap resolves to null', async () => {
+      mockOptions.bootstrap = vi.fn().mockResolvedValue(null);
+      service = new AngularSSRService(mockOptions);
+
+      await expect(service.onModuleInit()).rejects.toThrow(/resolved to null/);
+    });
+
+    it('throws a descriptive error when bootstrap resolves to undefined', async () => {
+      // eslint-disable-next-line unicorn/no-useless-undefined -- we explicitly want to exercise the undefined path
+      mockOptions.bootstrap = vi.fn().mockResolvedValue(undefined);
+      service = new AngularSSRService(mockOptions);
+
+      await expect(service.onModuleInit()).rejects.toThrow(/resolved to undefined/);
+    });
   });
 
   describe('render() — AngularAppEngine path (default fallback)', () => {

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -446,6 +446,27 @@ describe('AngularSSRService', () => {
       expect(engine.handle).toHaveBeenCalledTimes(1);
     });
 
+    it('emits a cache-hit debug log when ANGULAR_SSR_DEBUG is enabled', async () => {
+      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
+      const request = createMockRequest();
+      const response = createMockResponse();
+      await service.render(request, response);
+
+      const previous = process.env.ANGULAR_SSR_DEBUG;
+      process.env.ANGULAR_SSR_DEBUG = '1';
+      try {
+        await service.render(request, response);
+      } finally {
+        if (previous === undefined) {
+          Reflect.deleteProperty(process.env, 'ANGULAR_SSR_DEBUG');
+        } else {
+          process.env.ANGULAR_SSR_DEBUG = previous;
+        }
+      }
+
+      expect(engine.handle).toHaveBeenCalledTimes(1);
+    });
+
     it('should not cache when cache is disabled', async () => {
       const noCache = new AngularSSRService({ ...mockOptions, cache: false });
       await noCache.onModuleInit();

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -1,29 +1,39 @@
+import { REQUEST, REQUEST_CONTEXT } from '@angular/core';
+import { AngularAppEngine } from '@angular/ssr';
+import { AngularNodeAppEngine, CommonEngine } from '@angular/ssr/node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularSSRService, DEFAULT_CACHE_EXPIRATION_TIME } from './angular-ssr.service';
-import { REQUEST, RESPONSE } from './tokens';
 import type { AngularSSRModuleOptions, CacheStorage } from './interfaces';
 import type { Request, Response } from 'express';
 
-// Engine factories — each shapes the duck-type so the service routes to the
-// expected branch without needing access to the real Angular SSR classes.
+// Build engine instances that pass `instanceof` against the real classes
+// without paying the cost of a full Angular bootstrap. `Object.create`
+// gives us a prototype-linked instance whose only public surface is the
+// method we stub.
 
-const createAppEngine = () => ({
-  // No render method; constructor.name is 'Object' — falls through to the
-  // AngularAppEngine branch.
-  handle: vi.fn(),
-});
-
-const createNodeAppEngine = () => {
-  class AngularNodeAppEngine {
-    handle = vi.fn();
-  }
-  return new AngularNodeAppEngine();
+const createAppEngine = (): AngularAppEngine & { handle: ReturnType<typeof vi.fn> } => {
+  const engine = Object.create(AngularAppEngine.prototype) as AngularAppEngine & {
+    handle: ReturnType<typeof vi.fn>;
+  };
+  engine.handle = vi.fn();
+  return engine;
 };
 
-const createCommonEngine = () => ({
-  // CommonEngine has render() but not handle().
-  render: vi.fn(),
-});
+const createNodeAppEngine = (): AngularNodeAppEngine & { handle: ReturnType<typeof vi.fn> } => {
+  const engine = Object.create(AngularNodeAppEngine.prototype) as AngularNodeAppEngine & {
+    handle: ReturnType<typeof vi.fn>;
+  };
+  engine.handle = vi.fn();
+  return engine;
+};
+
+const createCommonEngine = (): CommonEngine & { render: ReturnType<typeof vi.fn> } => {
+  const engine = Object.create(CommonEngine.prototype) as CommonEngine & {
+    render: ReturnType<typeof vi.fn>;
+  };
+  engine.render = vi.fn();
+  return engine;
+};
 
 const createMockRequest = (overrides: Partial<Request> = {}): Request =>
   ({
@@ -37,7 +47,11 @@ const createMockRequest = (overrides: Partial<Request> = {}): Request =>
     hostname: 'localhost',
     originalUrl: '/test-page',
     url: '/test-page',
+    // `socket` and `headers.host` are required by
+    // `createWebRequestFromNodeRequest` from `@angular/ssr/node`.
+    socket: {},
     headers: {
+      host: 'localhost:3000',
       'user-agent': 'test-agent',
       accept: 'text/html',
     },
@@ -150,11 +164,16 @@ describe('AngularSSRService', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle requests with different protocols', async () => {
+    it('produces an HTTPS URL when the underlying socket is encrypted', async () => {
       const mockHtml = '<html><body>HTTPS</body></html>';
       engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue(mockHtml) });
 
-      await service.render(createMockRequest({ protocol: 'https' }), createMockResponse());
+      await service.render(
+        createMockRequest({
+          socket: { encrypted: true },
+        } as unknown as Partial<Request>),
+        createMockResponse(),
+      );
 
       const fetchRequest = engine.handle.mock.calls[0][0] as globalThis.Request;
       expect(fetchRequest.url).toContain('https://');
@@ -166,6 +185,7 @@ describe('AngularSSRService', () => {
 
       const request = createMockRequest({
         headers: {
+          host: 'localhost:3000',
           accept: ['text/html', 'application/json'],
           'user-agent': 'test',
         },
@@ -175,25 +195,14 @@ describe('AngularSSRService', () => {
       expect(result).toBe(mockHtml);
     });
 
-    it('passes the response into the engine via requestContext', async () => {
+    it('passes the request and response into the engine via requestContext', async () => {
       engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
 
+      const request = createMockRequest();
       const response = createMockResponse();
-      await service.render(createMockRequest(), response);
+      await service.render(request, response);
 
-      expect(engine.handle.mock.calls[0][1]).toEqual({ response });
-    });
-
-    it('falls back to localhost when the host header is missing', async () => {
-      engine.handle.mockResolvedValue({ text: vi.fn().mockResolvedValue('<html></html>') });
-
-      const request = createMockRequest({
-        get: vi.fn(),
-      } as unknown as Partial<Request>);
-      await service.render(request, createMockResponse());
-
-      const fetchRequest = engine.handle.mock.calls[0][0] as { url: string };
-      expect(fetchRequest.url).toContain('http://localhost/');
+      expect(engine.handle.mock.calls[0][1]).toEqual({ request, response });
     });
 
     it('falls back to "/" when neither originalUrl nor url is set', async () => {
@@ -214,6 +223,7 @@ describe('AngularSSRService', () => {
 
       const request = createMockRequest({
         headers: {
+          host: 'localhost:3000',
           accept: 'text/html',
           'x-empty': undefined,
         },
@@ -243,9 +253,9 @@ describe('AngularSSRService', () => {
       const response = createMockResponse();
       await service.render(request, response);
 
-      // For Node engine, the FIRST arg is the Express request itself, not a
-      // Web fetch Request — that's the entire point of this branch.
-      expect(engine.handle).toHaveBeenCalledWith(request, { response });
+      // For Node engine, the first arg is the Express request itself, not
+      // a Web fetch Request — that's the entire point of this branch.
+      expect(engine.handle).toHaveBeenCalledWith(request, { request, response });
     });
 
     it('returns null when handle resolves to null', async () => {
@@ -315,22 +325,28 @@ describe('AngularSSRService', () => {
       expect(engine.render.mock.calls.at(-1)?.[0].documentFilePath).toBe('/custom/index.html');
     });
 
-    it('injects per-request REQUEST and RESPONSE providers', async () => {
+    it("provides Angular's REQUEST (Web Fetch) and REQUEST_CONTEXT per render", async () => {
       engine.render.mockResolvedValue('<html></html>');
       const request = createMockRequest();
       const response = createMockResponse();
       await service.render(request, response);
 
-      const providers = engine.render.mock.calls[0][0].providers;
-      expect(providers).toEqual(
-        expect.arrayContaining([
-          { provide: REQUEST, useValue: request },
-          { provide: RESPONSE, useValue: response },
-        ]),
-      );
+      const providers = engine.render.mock.calls[0][0].providers as {
+        provide: unknown;
+        useValue: unknown;
+      }[];
+      const reqProvider = providers.find((p) => p.provide === REQUEST);
+      const ctxProvider = providers.find((p) => p.provide === REQUEST_CONTEXT);
+
+      expect(reqProvider).toBeDefined();
+      expect((reqProvider?.useValue as { url: string }).url).toContain('/test-page');
+      expect(ctxProvider).toEqual({
+        provide: REQUEST_CONTEXT,
+        useValue: { request, response },
+      });
     });
 
-    it('preserves user-supplied extraProviders alongside REQUEST/RESPONSE', async () => {
+    it('preserves user-supplied extraProviders alongside the Angular tokens', async () => {
       engine.render.mockResolvedValue('<html></html>');
       const extraProvider = { provide: 'CUSTOM', useValue: 42 };
       const customService = new AngularSSRService({
@@ -345,7 +361,7 @@ describe('AngularSSRService', () => {
         expect.arrayContaining([
           extraProvider,
           expect.objectContaining({ provide: REQUEST }),
-          expect.objectContaining({ provide: RESPONSE }),
+          expect.objectContaining({ provide: REQUEST_CONTEXT }),
         ]),
       );
     });
@@ -378,6 +394,31 @@ describe('AngularSSRService', () => {
       await customService.render(createMockRequest(), createMockResponse());
 
       expect(engine.render.mock.calls.at(-1)?.[0].bootstrap).toBeUndefined();
+    });
+
+    it('falls back to localhost in the rendered url when host is missing', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      await service.render(
+        createMockRequest({
+          get: vi.fn(),
+        } as unknown as Partial<Request>),
+        createMockResponse(),
+      );
+
+      expect(engine.render.mock.calls.at(-1)?.[0].url).toContain('http://localhost/');
+    });
+
+    it('falls back to "/" in the rendered url when no path is set', async () => {
+      engine.render.mockResolvedValue('<html></html>');
+      await service.render(
+        createMockRequest({
+          originalUrl: undefined,
+          url: undefined,
+        } as unknown as Partial<Request>),
+        createMockResponse(),
+      );
+
+      expect(engine.render.mock.calls.at(-1)?.[0].url).toBe('http://localhost:3000/');
     });
   });
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -1,9 +1,16 @@
 import { join } from 'node:path';
+import { REQUEST, REQUEST_CONTEXT } from '@angular/core';
+import { AngularAppEngine } from '@angular/ssr';
+import {
+  AngularNodeAppEngine,
+  CommonEngine,
+  createWebRequestFromNodeRequest,
+} from '@angular/ssr/node';
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { InMemoryCacheStorage } from './cache/in-memory-cache-storage';
 import { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
 import { DebugLogger } from './debug-logger';
-import { ANGULAR_SSR_OPTIONS, REQUEST, RESPONSE } from './tokens';
+import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type {
   AngularSSRModuleOptions,
   CacheKeyGenerator,
@@ -11,8 +18,6 @@ import type {
   CacheStorage,
   StaticProvider,
 } from './interfaces';
-import type { AngularAppEngine } from '@angular/ssr';
-import type { AngularNodeAppEngine, CommonEngine } from '@angular/ssr/node';
 import type { Request, Response } from 'express';
 
 /**
@@ -21,6 +26,15 @@ import type { Request, Response } from 'express';
 export const DEFAULT_CACHE_EXPIRATION_TIME = 60_000;
 
 type AngularEngine = AngularAppEngine | AngularNodeAppEngine | CommonEngine;
+
+/**
+ * Per-render context surfaced to Angular components via `@angular/core`'s
+ * `REQUEST_CONTEXT` injection token. Available on every engine path.
+ */
+export interface SSRRequestContext {
+  request: Request;
+  response: Response;
+}
 
 @Injectable()
 export class AngularSSRService implements OnModuleInit {
@@ -40,7 +54,7 @@ export class AngularSSRService implements OnModuleInit {
     this.cacheEnabled = cacheOptions !== false;
 
     if (this.cacheEnabled && cacheOptions) {
-      this.cacheStorage = cacheOptions.storage ?? new InMemoryCacheStorage();
+      this.cacheStorage = cacheOptions.storage ?? new InMemoryCacheStorage(cacheOptions.maxEntries);
       this.cacheKeyGenerator = cacheOptions.keyGenerator ?? new UrlCacheKeyGenerator();
       this.cacheExpiresIn = cacheOptions.expiresIn ?? DEFAULT_CACHE_EXPIRATION_TIME;
     } else {
@@ -60,9 +74,6 @@ export class AngularSSRService implements OnModuleInit {
     }
   }
 
-  /**
-   * Resolve cache options from the provided configuration
-   */
   private resolveCacheOptions(cache: boolean | CacheOptions | undefined): CacheOptions | false {
     if (cache === false) {
       return false;
@@ -74,9 +85,9 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   /**
-   * Detect the engine variant via duck-typing, with `options.engineType` as
-   * an explicit override for minified production builds where class names
-   * are unreliable.
+   * Detect the engine variant. Defaults to `instanceof` against the real
+   * `@angular/ssr` classes (minification-safe). `options.engineType`
+   * overrides for test fixtures or unusual setups.
    */
   private isCommonEngine(engine: AngularEngine): engine is CommonEngine {
     if (this.options.engineType === 'common') {
@@ -85,8 +96,7 @@ export class AngularSSRService implements OnModuleInit {
     if (this.options.engineType !== undefined) {
       return false;
     }
-    const candidate = engine as unknown as { render?: unknown; handle?: unknown };
-    return typeof candidate.render === 'function' && typeof candidate.handle !== 'function';
+    return engine instanceof CommonEngine;
   }
 
   private isNodeAppEngine(engine: AngularEngine): engine is AngularNodeAppEngine {
@@ -96,12 +106,8 @@ export class AngularSSRService implements OnModuleInit {
     if (this.options.engineType !== undefined) {
       return false;
     }
-    return engine.constructor.name === 'AngularNodeAppEngine';
+    return engine instanceof AngularNodeAppEngine;
   }
-
-  /**
-   * Render the Angular application for the given request.
-   */
 
   async render(request: Request, response: Response): Promise<string | null> {
     if (!this.angularEngine) {
@@ -154,8 +160,8 @@ export class AngularSSRService implements OnModuleInit {
     }
     const angularRequest: Request | globalThis.Request = this.isNodeAppEngine(engine)
       ? request
-      : this.createWebRequest(request);
-    return await this.handleAngularEngine(engine, angularRequest, response);
+      : createWebRequestFromNodeRequest(request);
+    return await this.handleAngularEngine(engine, angularRequest, { request, response });
   }
 
   private async renderWithCommonEngine(
@@ -170,10 +176,15 @@ export class AngularSSRService implements OnModuleInit {
       this.options.angularBootstrap ? await this.options.angularBootstrap() : undefined
     ) as Parameters<CommonEngine['render']>[0]['bootstrap'];
 
+    // Provide the same Angular tokens that AngularAppEngine /
+    // AngularNodeAppEngine wire automatically: REQUEST holds a Web Fetch
+    // Request and REQUEST_CONTEXT carries arbitrary per-render data
+    // (here: the original Express request + response).
+    const requestContext: SSRRequestContext = { request, response };
     const providers: StaticProvider[] = [
       ...(this.options.extraProviders ?? []),
-      { provide: REQUEST, useValue: request },
-      { provide: RESPONSE, useValue: response },
+      { provide: REQUEST, useValue: createWebRequestFromNodeRequest(request) },
+      { provide: REQUEST_CONTEXT, useValue: requestContext },
     ];
 
     return await engine.render({
@@ -182,22 +193,20 @@ export class AngularSSRService implements OnModuleInit {
       publicPath: this.options.browserDistFolder,
       url: this.getRequestUrl(request),
       inlineCriticalCss: this.options.inlineCriticalCss ?? true,
-      // Our StaticProvider mirrors @angular/core's structurally so the NestJS
-      // module doesn't pull in an Angular runtime import.
-      providers: providers as never,
+      providers,
     });
   }
 
   private async handleAngularEngine(
     engine: AngularNodeAppEngine | AngularAppEngine,
     request: Request | globalThis.Request,
-    response: Response,
+    requestContext: SSRRequestContext,
   ): Promise<string | null> {
     const handle = engine.handle.bind(engine) as (
       r: Request | globalThis.Request,
-      ctx?: Record<string, unknown>,
+      ctx?: SSRRequestContext,
     ) => Promise<{ text: () => Promise<string> } | null | undefined> | null;
-    const angularResponse = await handle(request, { response });
+    const angularResponse = await handle(request, requestContext);
     if (!angularResponse) {
       return null;
     }
@@ -219,35 +228,6 @@ export class AngularSSRService implements OnModuleInit {
     const host = request.get('host') ?? 'localhost';
     const originalUrl = request.originalUrl || request.url || '/';
     return `${protocol}://${host}${originalUrl}`;
-  }
-
-  /**
-   * Build a Web `Request` from the Express request for AngularAppEngine.
-   *
-   * We hand-roll this rather than reusing `createWebRequestFromNodeRequest`
-   * from `@angular/ssr/node` because that helper pulls in
-   * `@angular/platform-server` transitively, which downstream consumers (and
-   * our own tests) shouldn't have to install just to render with the
-   * lighter-weight engine variants.
-   */
-  private createWebRequest(expressRequest: Request): globalThis.Request {
-    const headers = new Headers();
-    for (const [key, value] of Object.entries(expressRequest.headers)) {
-      if (!value) {
-        continue;
-      }
-      if (Array.isArray(value)) {
-        for (const v of value) {
-          headers.append(key, v);
-        }
-      } else {
-        headers.set(key, value);
-      }
-    }
-    return new Request(this.getRequestUrl(expressRequest), {
-      method: expressRequest.method,
-      headers,
-    });
   }
 
   /**

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -1,13 +1,15 @@
 import { join } from 'node:path';
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { InMemoryCacheStorage } from './cache/in-memory-cache-storage';
 import { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
-import { ANGULAR_SSR_OPTIONS } from './tokens';
+import { DebugLogger } from './debug-logger';
+import { ANGULAR_SSR_OPTIONS, REQUEST, RESPONSE } from './tokens';
 import type {
   AngularSSRModuleOptions,
   CacheKeyGenerator,
   CacheOptions,
   CacheStorage,
+  StaticProvider,
 } from './interfaces';
 import type { AngularAppEngine } from '@angular/ssr';
 import type { AngularNodeAppEngine, CommonEngine } from '@angular/ssr/node';
@@ -22,7 +24,7 @@ type AngularEngine = AngularAppEngine | AngularNodeAppEngine | CommonEngine;
 
 @Injectable()
 export class AngularSSRService implements OnModuleInit {
-  private readonly logger = new Logger(AngularSSRService.name);
+  private readonly logger = new DebugLogger(AngularSSRService.name);
   private angularEngine: AngularEngine | null = null;
 
   private readonly cacheEnabled: boolean;
@@ -34,7 +36,6 @@ export class AngularSSRService implements OnModuleInit {
     @Inject(ANGULAR_SSR_OPTIONS)
     private readonly options: AngularSSRModuleOptions,
   ) {
-    // Initialize cache settings
     const cacheOptions = this.resolveCacheOptions(options.cache);
     this.cacheEnabled = cacheOptions !== false;
 
@@ -43,7 +44,6 @@ export class AngularSSRService implements OnModuleInit {
       this.cacheKeyGenerator = cacheOptions.keyGenerator ?? new UrlCacheKeyGenerator();
       this.cacheExpiresIn = cacheOptions.expiresIn ?? DEFAULT_CACHE_EXPIRATION_TIME;
     } else {
-      // Initialize with defaults even if disabled (for type safety)
       this.cacheStorage = new InMemoryCacheStorage();
       this.cacheKeyGenerator = new UrlCacheKeyGenerator();
       this.cacheExpiresIn = DEFAULT_CACHE_EXPIRATION_TIME;
@@ -51,9 +51,16 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   async onModuleInit(): Promise<void> {
+    this.logger.debug(
+      `Bootstrapping Angular SSR engine (engineType=${
+        this.options.engineType ?? 'auto'
+      }, browserDistFolder=${this.options.browserDistFolder})`,
+    );
     try {
       this.angularEngine = (await this.options.bootstrap()) as AngularEngine;
-      this.logger.log('Angular SSR engine initialized successfully');
+      this.logger.log(
+        `Angular SSR engine initialized (constructor=${this.angularEngine.constructor.name})`,
+      );
     } catch (error) {
       this.logger.error('Failed to initialize Angular SSR engine', error);
       throw error;
@@ -74,86 +81,69 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   /**
-   * Check if the engine is a CommonEngine
+   * Detect the engine variant via duck-typing, with `options.engineType` as
+   * an explicit override for minified production builds where class names
+   * are unreliable.
    */
   private isCommonEngine(engine: AngularEngine): engine is CommonEngine {
-    return engine.constructor.name === 'CommonEngine' || 'render' in engine;
+    if (this.options.engineType === 'common') {
+      return true;
+    }
+    if (this.options.engineType !== undefined) {
+      return false;
+    }
+    const candidate = engine as unknown as { render?: unknown; handle?: unknown };
+    return typeof candidate.render === 'function' && typeof candidate.handle !== 'function';
   }
 
-  /**
-   * Check if the engine is an AngularNodeAppEngine
-   */
   private isNodeAppEngine(engine: AngularEngine): engine is AngularNodeAppEngine {
+    if (this.options.engineType === 'node-app') {
+      return true;
+    }
+    if (this.options.engineType !== undefined) {
+      return false;
+    }
     return engine.constructor.name === 'AngularNodeAppEngine';
   }
 
   /**
-   * Render the Angular application for the given request
+   * Render the Angular application for the given request.
    */
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- engine branches (Common / Node / Fetch)
+
   async render(request: Request, response: Response): Promise<string | null> {
     if (!this.angularEngine) {
       throw new Error('Angular SSR engine not initialized');
     }
 
     const url = this.getRequestUrl(request);
+    const cacheable = this.isCacheable(request);
 
-    // Check cache first
-    if (this.cacheEnabled) {
+    this.logger.debug(`render() ${request.method} ${url} (cacheable=${String(cacheable)})`);
+
+    if (cacheable) {
       const cacheKey = this.cacheKeyGenerator.generateCacheKey(request);
       const cached = await this.cacheStorage.get(cacheKey);
-
       if (cached) {
-        this.logger.debug(`Cache hit for: ${url}`);
+        this.logger.debug(`Cache hit (key=${cacheKey})`);
         return cached.content;
       }
+      this.logger.debug(`Cache miss (key=${cacheKey})`);
     }
 
     try {
-      let html: string | null = null;
+      const html = await this.invokeEngine(this.angularEngine, request, response, url);
 
-      if (this.isCommonEngine(this.angularEngine)) {
-        // For CommonEngine, use the render method
-        const documentFilePath =
-          this.options.indexHtml ?? join(this.options.browserDistFolder, 'index.server.html');
-
-        // Get the actual bootstrap function (angularBootstrap returns a Promise that resolves to it)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- user-provided bootstrap
-        const bootstrap = this.options.angularBootstrap
-          ? await this.options.angularBootstrap()
-          : undefined;
-
-        /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Angular CommonEngine.render API */
-        html = await this.angularEngine.render({
-          bootstrap,
-          documentFilePath,
-          url,
-          providers: this.options.extraProviders as any,
-        });
-        /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
-      } else if (this.isNodeAppEngine(this.angularEngine)) {
-        // For AngularNodeAppEngine, pass the Express request directly
-        const angularResponse = await this.angularEngine.handle(request);
-        if (angularResponse) {
-          html = await angularResponse.text();
-        }
-      } else {
-        // For AngularAppEngine, create a fetch API Request
-        const angularRequest = this.createAngularRequest(request);
-        const angularResponse = await this.angularEngine.handle(angularRequest);
-        if (angularResponse) {
-          html = await angularResponse.text();
-        }
-      }
-
-      // Store in cache
-      if (this.cacheEnabled && html) {
+      if (cacheable && html) {
         const cacheKey = this.cacheKeyGenerator.generateCacheKey(request);
         await this.cacheStorage.set(cacheKey, {
           content: html,
           expiresAt: Date.now() + this.cacheExpiresIn,
         });
-        this.logger.debug(`Cached response for: ${url}`);
+        this.logger.debug(
+          `Cached response (key=${cacheKey}, ttlMs=${String(this.cacheExpiresIn)}, bytes=${String(html.length)})`,
+        );
+      } else if (html === null) {
+        this.logger.debug(`Engine returned null for ${url}`);
       }
 
       return html;
@@ -161,12 +151,105 @@ export class AngularSSRService implements OnModuleInit {
       this.logger.error(`Error rendering: ${url}`, error);
 
       if (this.options.errorHandler) {
+        this.logger.debug('Delegating to user-supplied errorHandler');
         this.options.errorHandler(error as Error, request, response);
         return null;
       }
 
       throw error;
     }
+  }
+
+  private async invokeEngine(
+    engine: AngularEngine,
+    request: Request,
+    response: Response,
+    url: string,
+  ): Promise<string | null> {
+    if (this.isCommonEngine(engine)) {
+      this.logger.debug('Routing to CommonEngine.render()');
+      return await this.renderWithCommonEngine(engine, request, response, url);
+    }
+    if (this.isNodeAppEngine(engine)) {
+      this.logger.debug('Routing to AngularNodeAppEngine.handle()');
+      return await this.renderWithNodeAppEngine(engine, request, response);
+    }
+    this.logger.debug('Routing to AngularAppEngine.handle()');
+    return await this.renderWithAppEngine(engine, request, response);
+  }
+
+  private async renderWithCommonEngine(
+    engine: CommonEngine,
+    request: Request,
+    response: Response,
+    url: string,
+  ): Promise<string | null> {
+    const documentFilePath =
+      this.options.indexHtml ?? join(this.options.browserDistFolder, 'index.server.html');
+
+    const bootstrap = (
+      this.options.angularBootstrap ? await this.options.angularBootstrap() : undefined
+    ) as Parameters<CommonEngine['render']>[0]['bootstrap'];
+
+    const providers: StaticProvider[] = [
+      ...(this.options.extraProviders ?? []),
+      { provide: REQUEST, useValue: request },
+      { provide: RESPONSE, useValue: response },
+    ];
+
+    return await engine.render({
+      bootstrap,
+      documentFilePath,
+      publicPath: this.options.browserDistFolder,
+      url,
+      inlineCriticalCss: this.options.inlineCriticalCss ?? true,
+      // CommonEngine's StaticProvider type comes from @angular/core; ours is
+      // a structurally-compatible mirror so consumers don't need an Angular
+      // import in their NestJS module.
+      providers: providers as never,
+    });
+  }
+
+  private async renderWithNodeAppEngine(
+    engine: AngularNodeAppEngine,
+    request: Request,
+    response: Response,
+  ): Promise<string | null> {
+    // engine.handle accepts (req, requestContext?). Express's Request extends
+    // Node's IncomingMessage, which is what AngularNodeAppEngine expects.
+    const handle = engine.handle.bind(engine) as (
+      r: Request,
+      ctx?: Record<string, unknown>,
+    ) => Promise<Response | null | undefined> | null;
+    const angularResponse = await handle(request, { response });
+    if (!angularResponse) {
+      return null;
+    }
+    return await (angularResponse as unknown as { text: () => Promise<string> }).text();
+  }
+
+  private async renderWithAppEngine(
+    engine: AngularAppEngine,
+    request: Request,
+    response: Response,
+  ): Promise<string | null> {
+    const angularRequest = this.createAngularRequest(request);
+    const handle = engine.handle.bind(engine) as (
+      r: globalThis.Request,
+      ctx?: Record<string, unknown>,
+    ) => Promise<Response | null | undefined> | null;
+    const angularResponse = await handle(angularRequest, { response });
+    if (!angularResponse) {
+      return null;
+    }
+    return await (angularResponse as unknown as { text: () => Promise<string> }).text();
+  }
+
+  /**
+   * Only GET and HEAD requests are cacheable.
+   */
+  private isCacheable(request: Request): boolean {
+    return this.cacheEnabled && (request.method === 'GET' || request.method === 'HEAD');
   }
 
   /**
@@ -185,17 +268,17 @@ export class AngularSSRService implements OnModuleInit {
   private createAngularRequest(expressRequest: Request): globalThis.Request {
     const url = this.getRequestUrl(expressRequest);
 
-    // Convert Express headers to Headers object
     const headers = new Headers();
     for (const [key, value] of Object.entries(expressRequest.headers)) {
-      if (value) {
-        if (Array.isArray(value)) {
-          for (const v of value) {
-            headers.append(key, v);
-          }
-        } else {
-          headers.set(key, value);
+      if (!value) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          headers.append(key, v);
         }
+      } else {
+        headers.set(key, value);
       }
     }
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -65,13 +65,24 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   async onModuleInit(): Promise<void> {
+    let engine: AngularEngine | null | undefined;
     try {
-      this.angularEngine = (await this.options.bootstrap()) as AngularEngine;
-      this.logger.log(`Angular SSR engine initialized (${this.angularEngine.constructor.name})`);
+      engine = (await this.options.bootstrap()) as AngularEngine | null | undefined;
     } catch (error) {
       this.logger.error('Failed to initialize Angular SSR engine', error);
       throw error;
     }
+    // Surface bad user configuration as a clear message instead of the
+    // `Cannot read properties of null (reading 'constructor')` TypeError
+    // that a bare .constructor.name access would produce.
+    if (engine === null || engine === undefined) {
+      const resolvedTo = engine === null ? 'null' : 'undefined';
+      const message = `AngularSSRModuleOptions.bootstrap() resolved to ${resolvedTo}; expected an AngularAppEngine, AngularNodeAppEngine, or CommonEngine instance.`;
+      this.logger.error(message);
+      throw new Error(message);
+    }
+    this.angularEngine = engine;
+    this.logger.log(`Angular SSR engine initialized (${engine.constructor.name})`);
   }
 
   private resolveCacheOptions(cache: boolean | CacheOptions | undefined): CacheOptions | false {

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -51,16 +51,9 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   async onModuleInit(): Promise<void> {
-    this.logger.debug(
-      `Bootstrapping Angular SSR engine (engineType=${
-        this.options.engineType ?? 'auto'
-      }, browserDistFolder=${this.options.browserDistFolder})`,
-    );
     try {
       this.angularEngine = (await this.options.bootstrap()) as AngularEngine;
-      this.logger.log(
-        `Angular SSR engine initialized (constructor=${this.angularEngine.constructor.name})`,
-      );
+      this.logger.log(`Angular SSR engine initialized (${this.angularEngine.constructor.name})`);
     } catch (error) {
       this.logger.error('Failed to initialize Angular SSR engine', error);
       throw error;
@@ -115,43 +108,34 @@ export class AngularSSRService implements OnModuleInit {
       throw new Error('Angular SSR engine not initialized');
     }
 
-    const url = this.getRequestUrl(request);
     const cacheable = this.isCacheable(request);
+    const cacheKey = cacheable ? this.cacheKeyGenerator.generateCacheKey(request) : null;
 
-    this.logger.debug(`render() ${request.method} ${url} (cacheable=${String(cacheable)})`);
-
-    if (cacheable) {
-      const cacheKey = this.cacheKeyGenerator.generateCacheKey(request);
+    if (cacheKey !== null) {
       const cached = await this.cacheStorage.get(cacheKey);
       if (cached) {
-        this.logger.debug(`Cache hit (key=${cacheKey})`);
+        if (this.logger.enabled()) {
+          this.logger.debug(`Cache hit (key=${cacheKey})`);
+        }
         return cached.content;
       }
-      this.logger.debug(`Cache miss (key=${cacheKey})`);
     }
 
     try {
-      const html = await this.invokeEngine(this.angularEngine, request, response, url);
+      const html = await this.invokeEngine(this.angularEngine, request, response);
 
-      if (cacheable && html) {
-        const cacheKey = this.cacheKeyGenerator.generateCacheKey(request);
+      if (cacheKey !== null && html) {
         await this.cacheStorage.set(cacheKey, {
           content: html,
           expiresAt: Date.now() + this.cacheExpiresIn,
         });
-        this.logger.debug(
-          `Cached response (key=${cacheKey}, ttlMs=${String(this.cacheExpiresIn)}, bytes=${String(html.length)})`,
-        );
-      } else if (html === null) {
-        this.logger.debug(`Engine returned null for ${url}`);
       }
 
       return html;
     } catch (error) {
-      this.logger.error(`Error rendering: ${url}`, error);
+      this.logger.error(`Error rendering: ${this.getRequestUrl(request)}`, error);
 
       if (this.options.errorHandler) {
-        this.logger.debug('Delegating to user-supplied errorHandler');
         this.options.errorHandler(error as Error, request, response);
         return null;
       }
@@ -164,25 +148,20 @@ export class AngularSSRService implements OnModuleInit {
     engine: AngularEngine,
     request: Request,
     response: Response,
-    url: string,
   ): Promise<string | null> {
     if (this.isCommonEngine(engine)) {
-      this.logger.debug('Routing to CommonEngine.render()');
-      return await this.renderWithCommonEngine(engine, request, response, url);
+      return await this.renderWithCommonEngine(engine, request, response);
     }
-    if (this.isNodeAppEngine(engine)) {
-      this.logger.debug('Routing to AngularNodeAppEngine.handle()');
-      return await this.renderWithNodeAppEngine(engine, request, response);
-    }
-    this.logger.debug('Routing to AngularAppEngine.handle()');
-    return await this.renderWithAppEngine(engine, request, response);
+    const angularRequest: Request | globalThis.Request = this.isNodeAppEngine(engine)
+      ? request
+      : this.createWebRequest(request);
+    return await this.handleAngularEngine(engine, angularRequest, response);
   }
 
   private async renderWithCommonEngine(
     engine: CommonEngine,
     request: Request,
     response: Response,
-    url: string,
   ): Promise<string | null> {
     const documentFilePath =
       this.options.indexHtml ?? join(this.options.browserDistFolder, 'index.server.html');
@@ -201,48 +180,28 @@ export class AngularSSRService implements OnModuleInit {
       bootstrap,
       documentFilePath,
       publicPath: this.options.browserDistFolder,
-      url,
+      url: this.getRequestUrl(request),
       inlineCriticalCss: this.options.inlineCriticalCss ?? true,
-      // CommonEngine's StaticProvider type comes from @angular/core; ours is
-      // a structurally-compatible mirror so consumers don't need an Angular
-      // import in their NestJS module.
+      // Our StaticProvider mirrors @angular/core's structurally so the NestJS
+      // module doesn't pull in an Angular runtime import.
       providers: providers as never,
     });
   }
 
-  private async renderWithNodeAppEngine(
-    engine: AngularNodeAppEngine,
-    request: Request,
+  private async handleAngularEngine(
+    engine: AngularNodeAppEngine | AngularAppEngine,
+    request: Request | globalThis.Request,
     response: Response,
   ): Promise<string | null> {
-    // engine.handle accepts (req, requestContext?). Express's Request extends
-    // Node's IncomingMessage, which is what AngularNodeAppEngine expects.
     const handle = engine.handle.bind(engine) as (
-      r: Request,
+      r: Request | globalThis.Request,
       ctx?: Record<string, unknown>,
-    ) => Promise<Response | null | undefined> | null;
+    ) => Promise<{ text: () => Promise<string> } | null | undefined> | null;
     const angularResponse = await handle(request, { response });
     if (!angularResponse) {
       return null;
     }
-    return await (angularResponse as unknown as { text: () => Promise<string> }).text();
-  }
-
-  private async renderWithAppEngine(
-    engine: AngularAppEngine,
-    request: Request,
-    response: Response,
-  ): Promise<string | null> {
-    const angularRequest = this.createAngularRequest(request);
-    const handle = engine.handle.bind(engine) as (
-      r: globalThis.Request,
-      ctx?: Record<string, unknown>,
-    ) => Promise<Response | null | undefined> | null;
-    const angularResponse = await handle(angularRequest, { response });
-    if (!angularResponse) {
-      return null;
-    }
-    return await (angularResponse as unknown as { text: () => Promise<string> }).text();
+    return await angularResponse.text();
   }
 
   /**
@@ -263,11 +222,15 @@ export class AngularSSRService implements OnModuleInit {
   }
 
   /**
-   * Create a native Request object compatible with Angular SSR
+   * Build a Web `Request` from the Express request for AngularAppEngine.
+   *
+   * We hand-roll this rather than reusing `createWebRequestFromNodeRequest`
+   * from `@angular/ssr/node` because that helper pulls in
+   * `@angular/platform-server` transitively, which downstream consumers (and
+   * our own tests) shouldn't have to install just to render with the
+   * lighter-weight engine variants.
    */
-  private createAngularRequest(expressRequest: Request): globalThis.Request {
-    const url = this.getRequestUrl(expressRequest);
-
+  private createWebRequest(expressRequest: Request): globalThis.Request {
     const headers = new Headers();
     for (const [key, value] of Object.entries(expressRequest.headers)) {
       if (!value) {
@@ -281,8 +244,7 @@ export class AngularSSRService implements OnModuleInit {
         headers.set(key, value);
       }
     }
-
-    return new Request(url, {
+    return new Request(this.getRequestUrl(expressRequest), {
       method: expressRequest.method,
       headers,
     });

--- a/lib/cache/in-memory-cache-storage.spec.ts
+++ b/lib/cache/in-memory-cache-storage.spec.ts
@@ -226,4 +226,67 @@ describe('InMemoryCacheStorage', () => {
       expect(storage.size).toBe(0);
     });
   });
+
+  describe('LRU eviction', () => {
+    const fresh = (suffix: string): CacheEntry => ({
+      content: `<html>${suffix}</html>`,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    it('evicts the least-recently-used entry when over capacity', () => {
+      const bounded = new InMemoryCacheStorage(2);
+      bounded.set('a', fresh('a'));
+      bounded.set('b', fresh('b'));
+      bounded.set('c', fresh('c'));
+
+      expect(bounded.size).toBe(2);
+      expect(bounded.has('a')).toBe(false);
+      expect(bounded.has('b')).toBe(true);
+      expect(bounded.has('c')).toBe(true);
+    });
+
+    it('promotes an entry to most-recently-used on get()', () => {
+      const bounded = new InMemoryCacheStorage(2);
+      bounded.set('a', fresh('a'));
+      bounded.set('b', fresh('b'));
+
+      // Touch 'a' so 'b' becomes the LRU candidate.
+      bounded.get('a');
+      bounded.set('c', fresh('c'));
+
+      expect(bounded.has('a')).toBe(true);
+      expect(bounded.has('b')).toBe(false);
+      expect(bounded.has('c')).toBe(true);
+    });
+
+    it('refreshes recency on a duplicate set()', () => {
+      const bounded = new InMemoryCacheStorage(2);
+      bounded.set('a', fresh('a'));
+      bounded.set('b', fresh('b'));
+      bounded.set('a', fresh('a-v2'));
+      bounded.set('c', fresh('c'));
+
+      expect(bounded.has('a')).toBe(true);
+      expect(bounded.has('b')).toBe(false);
+      expect(bounded.has('c')).toBe(true);
+      expect(bounded.get('a')?.content).toBe('<html>a-v2</html>');
+    });
+
+    it('does not bound size when maxEntries=0', () => {
+      const unbounded = new InMemoryCacheStorage(0);
+      for (let i = 0; i < 50; i += 1) {
+        unbounded.set(`k${String(i)}`, fresh(`v${String(i)}`));
+      }
+      expect(unbounded.size).toBe(50);
+    });
+
+    it('uses the documented default cap when no argument is given', () => {
+      // 1024 is the default; assert smaller-than-default does not evict.
+      const defaulted = new InMemoryCacheStorage();
+      for (let i = 0; i < 100; i += 1) {
+        defaulted.set(`k${String(i)}`, fresh(`v${String(i)}`));
+      }
+      expect(defaulted.size).toBe(100);
+    });
+  });
 });

--- a/lib/cache/in-memory-cache-storage.ts
+++ b/lib/cache/in-memory-cache-storage.ts
@@ -1,8 +1,8 @@
 import type { CacheEntry, CacheStorage } from '../interfaces';
 
 /**
- * Default unbounded entry cap. The cache grows up to 1024 distinct keys
- * before evicting the least-recently-used entry on the next `set`.
+ * Default upper bound on cached entries. Once the cache holds this many
+ * distinct keys, the next `set` evicts the least-recently-used entry.
  */
 export const DEFAULT_CACHE_MAX_ENTRIES = 1024;
 

--- a/lib/cache/in-memory-cache-storage.ts
+++ b/lib/cache/in-memory-cache-storage.ts
@@ -1,28 +1,53 @@
 import type { CacheEntry, CacheStorage } from '../interfaces';
 
 /**
- * Default in-memory cache storage implementation
+ * Default unbounded entry cap. The cache grows up to 1024 distinct keys
+ * before evicting the least-recently-used entry on the next `set`.
+ */
+export const DEFAULT_CACHE_MAX_ENTRIES = 1024;
+
+/**
+ * In-memory `CacheStorage` with LRU eviction.
+ *
+ * The Map's insertion-order iteration is leveraged for recency tracking:
+ * every `get` (and `set` of an existing key) re-inserts the entry, so the
+ * first key returned by `cache.keys()` is always the least-recently used.
+ * When `set` would exceed `maxEntries`, the oldest entries are dropped
+ * until the size is back under the limit.
+ *
+ * @param maxEntries — upper bound on cached entries. Pass `0` (or a
+ *   negative number) to disable the bound entirely (not recommended for
+ *   production, but useful in tests).
  */
 export class InMemoryCacheStorage implements CacheStorage {
-  private cache = new Map<string, CacheEntry>();
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries: number = DEFAULT_CACHE_MAX_ENTRIES) {
+    this.maxEntries = maxEntries;
+  }
 
   get(key: string): CacheEntry | undefined {
     const entry = this.cache.get(key);
     if (!entry) {
       return undefined;
     }
-
-    // Check if entry has expired
     if (Date.now() > entry.expiresAt) {
       this.cache.delete(key);
       return undefined;
     }
-
+    // Mark as most-recently-used by re-inserting at the tail.
+    this.cache.delete(key);
+    this.cache.set(key, entry);
     return entry;
   }
 
   set(key: string, entry: CacheEntry): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
     this.cache.set(key, entry);
+    this.evictIfOverCapacity();
   }
 
   delete(key: string): boolean {
@@ -34,19 +59,18 @@ export class InMemoryCacheStorage implements CacheStorage {
   }
 
   has(key: string): boolean {
-    const entry = this.get(key);
-    return entry !== undefined;
+    return this.get(key) !== undefined;
   }
 
   /**
-   * Get the current size of the cache
+   * Current entry count (including any not-yet-pruned expired entries).
    */
   get size(): number {
     return this.cache.size;
   }
 
   /**
-   * Remove all expired entries from the cache
+   * Remove all expired entries.
    */
   prune(): void {
     const now = Date.now();
@@ -54,6 +78,18 @@ export class InMemoryCacheStorage implements CacheStorage {
       if (now > entry.expiresAt) {
         this.cache.delete(key);
       }
+    }
+  }
+
+  private evictIfOverCapacity(): void {
+    if (this.maxEntries <= 0) {
+      return;
+    }
+    for (const oldest of this.cache.keys()) {
+      if (this.cache.size <= this.maxEntries) {
+        return;
+      }
+      this.cache.delete(oldest);
     }
   }
 }

--- a/lib/cache/url-cache-key-generator.spec.ts
+++ b/lib/cache/url-cache-key-generator.spec.ts
@@ -3,107 +3,97 @@ import { UrlCacheKeyGenerator } from './url-cache-key-generator';
 import type { Request } from 'express';
 
 describe('UrlCacheKeyGenerator', () => {
-  let generator: UrlCacheKeyGenerator;
+  const generator = new UrlCacheKeyGenerator();
 
-  beforeEach(() => {
-    generator = new UrlCacheKeyGenerator();
-  });
+  const make = (overrides: Partial<Request> = {}): Request =>
+    ({
+      method: 'GET',
+      hostname: 'example.com',
+      originalUrl: '/products/123',
+      url: '/products/123',
+      ...overrides,
+    }) as unknown as Request;
 
   describe('generateCacheKey()', () => {
-    it('should generate key from hostname and originalUrl', () => {
-      const request = {
-        hostname: 'example.com',
-        originalUrl: '/products/123',
-        url: '/products/123',
-      } as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/products/123');
+    it('prefixes the HTTP method, lower-cases the host, and preserves the URL', () => {
+      expect(generator.generateCacheKey(make())).toBe('GET example.com/products/123');
     });
 
-    it('should convert key to lowercase', () => {
-      const request = {
-        hostname: 'Example.COM',
-        originalUrl: '/Products/ABC',
-        url: '/Products/ABC',
-      } as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/products/abc');
+    it('lower-cases the hostname only — paths stay case-sensitive', () => {
+      const key = generator.generateCacheKey(
+        make({ hostname: 'Example.COM', originalUrl: '/Products/ABC', url: '/Products/ABC' }),
+      );
+      expect(key).toBe('GET example.com/Products/ABC');
     });
 
-    it('should use default hostname when not provided', () => {
-      const request = {
-        hostname: undefined,
-        originalUrl: '/page',
-        url: '/page',
-      } as unknown as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('localhost/page');
+    it('uses default hostname when not provided', () => {
+      const key = generator.generateCacheKey(
+        make({
+          hostname: undefined,
+          originalUrl: '/page',
+          url: '/page',
+        } as unknown as Partial<Request>),
+      );
+      expect(key).toBe('GET localhost/page');
     });
 
-    it('should fallback to url when originalUrl is not provided', () => {
-      const request = {
-        hostname: 'example.com',
-        originalUrl: undefined,
-        url: '/fallback-page',
-      } as unknown as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/fallback-page');
+    it('falls back to url when originalUrl is missing', () => {
+      const key = generator.generateCacheKey(
+        make({ originalUrl: undefined, url: '/fallback-page' } as unknown as Partial<Request>),
+      );
+      expect(key).toBe('GET example.com/fallback-page');
     });
 
-    it('should use root path when neither originalUrl nor url is provided', () => {
-      const request = {
-        hostname: 'example.com',
-        originalUrl: undefined,
-        url: undefined,
-      } as unknown as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/');
+    it('uses "/" when neither originalUrl nor url is provided', () => {
+      const key = generator.generateCacheKey(
+        make({ originalUrl: undefined, url: undefined } as unknown as Partial<Request>),
+      );
+      expect(key).toBe('GET example.com/');
     });
 
-    it('should handle query strings', () => {
-      const request = {
-        hostname: 'example.com',
-        originalUrl: '/search?q=test&page=1',
-        url: '/search?q=test&page=1',
-      } as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/search?q=test&page=1');
+    it('preserves query strings', () => {
+      const key = generator.generateCacheKey(
+        make({ originalUrl: '/search?q=test&page=1', url: '/search?q=test&page=1' }),
+      );
+      expect(key).toBe('GET example.com/search?q=test&page=1');
     });
 
-    it('should handle hash fragments', () => {
-      const request = {
-        hostname: 'example.com',
-        originalUrl: '/page#section',
-        url: '/page#section',
-      } as Request;
-
-      const key = generator.generateCacheKey(request);
-
-      expect(key).toBe('example.com/page#section');
+    it('preserves hash fragments', () => {
+      const key = generator.generateCacheKey(
+        make({ originalUrl: '/page#section', url: '/page#section' }),
+      );
+      expect(key).toBe('GET example.com/page#section');
     });
 
-    it('should handle complex URLs', () => {
-      const request = {
-        hostname: 'api.example.com',
-        originalUrl: '/v1/users/123/posts?sort=date&order=desc',
-        url: '/v1/users/123/posts?sort=date&order=desc',
-      } as Request;
+    it('handles complex URLs without lower-casing the path', () => {
+      const key = generator.generateCacheKey(
+        make({
+          hostname: 'API.example.com',
+          originalUrl: '/v1/Users/123/posts?sort=date',
+          url: '/v1/Users/123/posts?sort=date',
+        }),
+      );
+      expect(key).toBe('GET api.example.com/v1/Users/123/posts?sort=date');
+    });
 
-      const key = generator.generateCacheKey(request);
+    it('produces distinct keys for different methods on the same URL', () => {
+      const get = generator.generateCacheKey(make({ method: 'GET' }));
+      const post = generator.generateCacheKey(make({ method: 'POST' }));
+      expect(get).not.toBe(post);
+    });
 
-      expect(key).toBe('api.example.com/v1/users/123/posts?sort=date&order=desc');
+    it('uppercases the method for consistency', () => {
+      const key = generator.generateCacheKey(
+        make({ method: 'get' } as unknown as Partial<Request>),
+      );
+      expect(key).toBe('GET example.com/products/123');
+    });
+
+    it('defaults to GET when method is missing', () => {
+      const key = generator.generateCacheKey(
+        make({ method: undefined } as unknown as Partial<Request>),
+      );
+      expect(key).toBe('GET example.com/products/123');
     });
   });
 });

--- a/lib/cache/url-cache-key-generator.spec.ts
+++ b/lib/cache/url-cache-key-generator.spec.ts
@@ -95,5 +95,11 @@ describe('UrlCacheKeyGenerator', () => {
       );
       expect(key).toBe('GET example.com/products/123');
     });
+
+    it('collapses HEAD to GET so probes share the slot with the real render', () => {
+      const get = generator.generateCacheKey(make({ method: 'GET' }));
+      const head = generator.generateCacheKey(make({ method: 'HEAD' }));
+      expect(head).toBe(get);
+    });
   });
 });

--- a/lib/cache/url-cache-key-generator.ts
+++ b/lib/cache/url-cache-key-generator.ts
@@ -2,13 +2,18 @@ import type { CacheKeyGenerator } from '../interfaces';
 import type { Request } from 'express';
 
 /**
- * Default cache key: `<METHOD> <host>/<path?query>`. Method is included to
- * stop verb collisions; host is lower-cased (RFC 3986); path stays
- * case-sensitive.
+ * Default cache key: `<METHOD> <host>/<path?query>`. Host is lower-cased
+ * (RFC 3986); path and query stay case-sensitive.
+ *
+ * HEAD is collapsed to GET so a HEAD probe (load balancer health check,
+ * crawler pre-fetch, etc.) hits the same slot as the subsequent GET —
+ * the response body is identical and Express strips it for HEAD
+ * automatically.
  */
 export class UrlCacheKeyGenerator implements CacheKeyGenerator {
   generateCacheKey(request: Request): string {
-    const method = (request.method || 'GET').toUpperCase();
+    const rawMethod = (request.method || 'GET').toUpperCase();
+    const method = rawMethod === 'HEAD' ? 'GET' : rawMethod;
     const hostname = (request.hostname || 'localhost').toLowerCase();
     const url = request.originalUrl || request.url || '/';
     return `${method} ${hostname}${url}`;

--- a/lib/cache/url-cache-key-generator.ts
+++ b/lib/cache/url-cache-key-generator.ts
@@ -2,13 +2,20 @@ import type { CacheKeyGenerator } from '../interfaces';
 import type { Request } from 'express';
 
 /**
- * Default cache key generator based on URL
+ * Default cache key generator: combines HTTP method, hostname, and the full
+ * request URL.
+ *
+ * - Method is included so `GET /foo` and `POST /foo` cannot collide.
+ * - Hostname is lower-cased per RFC 3986 (host component is case-insensitive).
+ * - Path and query string are preserved as-is — paths are case-sensitive per
+ *   RFC 3986 and lower-casing them would collapse `/Users/Alice` and
+ *   `/users/alice` into the same cache slot.
  */
 export class UrlCacheKeyGenerator implements CacheKeyGenerator {
   generateCacheKey(request: Request): string {
-    // Combine hostname and original URL for unique cache key
-    const hostname = request.hostname || 'localhost';
+    const method = (request.method || 'GET').toUpperCase();
+    const hostname = (request.hostname || 'localhost').toLowerCase();
     const url = request.originalUrl || request.url || '/';
-    return `${hostname}${url}`.toLowerCase();
+    return `${method} ${hostname}${url}`;
   }
 }

--- a/lib/cache/url-cache-key-generator.ts
+++ b/lib/cache/url-cache-key-generator.ts
@@ -2,14 +2,9 @@ import type { CacheKeyGenerator } from '../interfaces';
 import type { Request } from 'express';
 
 /**
- * Default cache key generator: combines HTTP method, hostname, and the full
- * request URL.
- *
- * - Method is included so `GET /foo` and `POST /foo` cannot collide.
- * - Hostname is lower-cased per RFC 3986 (host component is case-insensitive).
- * - Path and query string are preserved as-is — paths are case-sensitive per
- *   RFC 3986 and lower-casing them would collapse `/Users/Alice` and
- *   `/users/alice` into the same cache slot.
+ * Default cache key: `<METHOD> <host>/<path?query>`. Method is included to
+ * stop verb collisions; host is lower-cased (RFC 3986); path stays
+ * case-sensitive.
  */
 export class UrlCacheKeyGenerator implements CacheKeyGenerator {
   generateCacheKey(request: Request): string {

--- a/lib/debug-logger.spec.ts
+++ b/lib/debug-logger.spec.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ANGULAR_SSR_DEBUG_ENV, DebugLogger, isDebugEnabled } from './debug-logger';
+
+describe('debug-logger', () => {
+  const originalValue = process.env[ANGULAR_SSR_DEBUG_ENV];
+
+  beforeEach(() => {
+    Reflect.deleteProperty(process.env, ANGULAR_SSR_DEBUG_ENV);
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      Reflect.deleteProperty(process.env, ANGULAR_SSR_DEBUG_ENV);
+    } else {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = originalValue;
+    }
+    vi.clearAllMocks();
+  });
+
+  describe('isDebugEnabled', () => {
+    it('returns false when env var is unset', () => {
+      expect(isDebugEnabled('AnyContext')).toBe(false);
+    });
+
+    it('returns false when env var is empty', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '';
+      expect(isDebugEnabled('AnyContext')).toBe(false);
+    });
+
+    it('returns false when env var is whitespace only', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '   ';
+      expect(isDebugEnabled('AnyContext')).toBe(false);
+    });
+
+    for (const value of ['1', 'true', 'yes', 'on', 'all', '*']) {
+      it(`returns true for any context when env var is "${value}"`, () => {
+        process.env[ANGULAR_SSR_DEBUG_ENV] = value;
+        expect(isDebugEnabled('Whatever')).toBe(true);
+      });
+    }
+
+    it('treats values case-insensitively', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'TRUE';
+      expect(isDebugEnabled()).toBe(true);
+    });
+
+    it('returns true only for matching contexts when given a comma list', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'AngularSSRService,AngularSSRMiddleware';
+      expect(isDebugEnabled('AngularSSRService')).toBe(true);
+      expect(isDebugEnabled('AngularSSRMiddleware')).toBe(true);
+      expect(isDebugEnabled('AngularSSRModule')).toBe(false);
+    });
+
+    it('returns false when no context is supplied with a context list', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'AngularSSRService';
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    it('matches contexts case-insensitively', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'angularssrservice';
+      expect(isDebugEnabled('AngularSSRService')).toBe(true);
+    });
+
+    it('tolerates whitespace inside the comma list', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = ' AngularSSRService , AngularSSRMiddleware ';
+      expect(isDebugEnabled('AngularSSRService')).toBe(true);
+    });
+
+    it('re-reads env on each call so toggling at runtime takes effect', () => {
+      expect(isDebugEnabled('A')).toBe(false);
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      expect(isDebugEnabled('A')).toBe(true);
+      Reflect.deleteProperty(process.env, ANGULAR_SSR_DEBUG_ENV);
+      expect(isDebugEnabled('A')).toBe(false);
+    });
+  });
+
+  describe('DebugLogger', () => {
+    it('reports enabled() based on env var', () => {
+      const logger = new DebugLogger('Ctx');
+      expect(logger.enabled()).toBe(false);
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      expect(logger.enabled()).toBe(true);
+    });
+
+    it('suppresses log() when disabled', () => {
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { log: ReturnType<typeof vi.fn> } }).logger;
+      inner.log = vi.fn();
+
+      logger.log('hello');
+      expect(inner.log).not.toHaveBeenCalled();
+
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      logger.log('hello');
+      expect(inner.log).toHaveBeenCalledWith('hello');
+    });
+
+    it('suppresses debug() when disabled', () => {
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { debug: ReturnType<typeof vi.fn> } }).logger;
+      inner.debug = vi.fn();
+
+      logger.debug('msg');
+      expect(inner.debug).not.toHaveBeenCalled();
+
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      logger.debug('msg');
+      expect(inner.debug).toHaveBeenCalledWith('msg');
+    });
+
+    it('suppresses verbose() when disabled', () => {
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { verbose: ReturnType<typeof vi.fn> } }).logger;
+      inner.verbose = vi.fn();
+
+      logger.verbose('msg');
+      expect(inner.verbose).not.toHaveBeenCalled();
+
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      logger.verbose('msg');
+      expect(inner.verbose).toHaveBeenCalledWith('msg');
+    });
+
+    it('always emits warn() regardless of env', () => {
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { warn: ReturnType<typeof vi.fn> } }).logger;
+      inner.warn = vi.fn();
+
+      logger.warn('careful');
+      expect(inner.warn).toHaveBeenCalledWith('careful');
+    });
+
+    it('always emits error() regardless of env', () => {
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { error: ReturnType<typeof vi.fn> } }).logger;
+      inner.error = vi.fn();
+
+      logger.error('boom');
+      expect(inner.error).toHaveBeenCalledWith('boom');
+    });
+
+    it('respects per-context filtering for log()', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'OtherContext';
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { log: ReturnType<typeof vi.fn> } }).logger;
+      inner.log = vi.fn();
+
+      logger.log('msg');
+      expect(inner.log).not.toHaveBeenCalled();
+
+      process.env[ANGULAR_SSR_DEBUG_ENV] = 'Ctx';
+      logger.log('msg');
+      expect(inner.log).toHaveBeenCalled();
+    });
+
+    it('forwards optional message arguments', () => {
+      process.env[ANGULAR_SSR_DEBUG_ENV] = '1';
+      const logger = new DebugLogger('Ctx');
+      const inner = (logger as unknown as { logger: { debug: ReturnType<typeof vi.fn> } }).logger;
+      inner.debug = vi.fn();
+
+      logger.debug('primary', 'extra');
+      expect(inner.debug).toHaveBeenCalledWith('primary', 'extra');
+    });
+  });
+});

--- a/lib/debug-logger.ts
+++ b/lib/debug-logger.ts
@@ -1,0 +1,89 @@
+import { Logger } from '@nestjs/common';
+
+/**
+ * Environment variable that toggles debug-level logging across this module.
+ *
+ * Accepted values:
+ *   - unset / empty:        debug logs are silenced; warnings & errors still emit.
+ *   - `1` / `true` / `yes` / `on` / `all` / `*`:  enable debug logging for every context.
+ *   - comma-separated list (e.g. `module,service`):  enable debug only for the
+ *     listed contexts. Matching is case-insensitive against `DebugLogger`'s
+ *     declared context.
+ *
+ * The flag is re-read on every call so it can be toggled at runtime without
+ * restarting the process — useful for production triage.
+ */
+export const ANGULAR_SSR_DEBUG_ENV = 'ANGULAR_SSR_DEBUG';
+
+const ALL_VALUES = new Set(['1', 'true', 'yes', 'on', 'all', '*']);
+
+/**
+ * Pure helper — exported so callers can branch on debug state without paying
+ * the cost of building a log message.
+ */
+export function isDebugEnabled(context?: string): boolean {
+  const raw = process.env[ANGULAR_SSR_DEBUG_ENV];
+  if (!raw) {
+    return false;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    return false;
+  }
+  if (ALL_VALUES.has(trimmed)) {
+    return true;
+  }
+  if (!context) {
+    return false;
+  }
+  return trimmed
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .includes(context.toLowerCase());
+}
+
+/**
+ * Drop-in wrapper around `@nestjs/common`'s `Logger` that gates `log`,
+ * `debug`, and `verbose` calls behind the `ANGULAR_SSR_DEBUG` env flag.
+ *
+ * Warnings and errors are never gated — those represent real conditions an
+ * operator needs to see regardless of debug mode.
+ */
+export class DebugLogger {
+  private readonly logger: Logger;
+
+  constructor(private readonly context: string) {
+    this.logger = new Logger(context);
+  }
+
+  enabled(): boolean {
+    return isDebugEnabled(this.context);
+  }
+
+  log(message: unknown, ...optional: unknown[]): void {
+    if (this.enabled()) {
+      this.logger.log(message as string, ...(optional as string[]));
+    }
+  }
+
+  debug(message: unknown, ...optional: unknown[]): void {
+    if (this.enabled()) {
+      this.logger.debug(message as string, ...(optional as string[]));
+    }
+  }
+
+  verbose(message: unknown, ...optional: unknown[]): void {
+    if (this.enabled()) {
+      this.logger.verbose(message as string, ...(optional as string[]));
+    }
+  }
+
+  warn(message: unknown, ...optional: unknown[]): void {
+    this.logger.warn(message as string, ...(optional as string[]));
+  }
+
+  error(message: unknown, ...optional: unknown[]): void {
+    this.logger.error(message as string, ...(optional as string[]));
+  }
+}

--- a/lib/debug-logger.ts
+++ b/lib/debug-logger.ts
@@ -1,46 +1,67 @@
 import { Logger } from '@nestjs/common';
 
 /**
- * Environment variable that toggles debug-level logging across this module.
+ * Env flag controlling debug-level logging. Re-read on every call so it can
+ * be toggled at runtime without restarting the process.
  *
- * Accepted values:
- *   - unset / empty:        debug logs are silenced; warnings & errors still emit.
- *   - `1` / `true` / `yes` / `on` / `all` / `*`:  enable debug logging for every context.
- *   - comma-separated list (e.g. `module,service`):  enable debug only for the
- *     listed contexts. Matching is case-insensitive against `DebugLogger`'s
- *     declared context.
- *
- * The flag is re-read on every call so it can be toggled at runtime without
- * restarting the process — useful for production triage.
+ * Values: unset/empty disables; `1`/`true`/`yes`/`on`/`all`/`*` enables every
+ * context; comma-separated list enables only the named contexts (case-insensitive).
  */
 export const ANGULAR_SSR_DEBUG_ENV = 'ANGULAR_SSR_DEBUG';
 
 const ALL_VALUES = new Set(['1', 'true', 'yes', 'on', 'all', '*']);
 
-/**
- * Pure helper — exported so callers can branch on debug state without paying
- * the cost of building a log message.
- */
-export function isDebugEnabled(context?: string): boolean {
-  const raw = process.env[ANGULAR_SSR_DEBUG_ENV];
+interface ParsedFlag {
+  matchAll: boolean;
+  contexts: ReadonlySet<string>;
+}
+
+const EMPTY_FLAG: ParsedFlag = { matchAll: false, contexts: new Set() };
+
+let cachedRaw: string | undefined;
+let cachedFlag: ParsedFlag = EMPTY_FLAG;
+
+function parseFlag(raw: string | undefined): ParsedFlag {
   if (!raw) {
-    return false;
+    return EMPTY_FLAG;
   }
   const trimmed = raw.trim().toLowerCase();
   if (!trimmed) {
-    return false;
+    return EMPTY_FLAG;
   }
   if (ALL_VALUES.has(trimmed)) {
+    return { matchAll: true, contexts: new Set() };
+  }
+  const contexts = new Set(
+    trimmed
+      .split(',')
+      .map((segment) => segment.trim())
+      .filter(Boolean),
+  );
+  return { matchAll: false, contexts };
+}
+
+function getFlag(): ParsedFlag {
+  const raw = process.env[ANGULAR_SSR_DEBUG_ENV];
+  if (raw !== cachedRaw) {
+    cachedRaw = raw;
+    cachedFlag = parseFlag(raw);
+  }
+  return cachedFlag;
+}
+
+/**
+ * Branch on debug state without paying for log-message construction.
+ */
+export function isDebugEnabled(context?: string): boolean {
+  const flag = getFlag();
+  if (flag.matchAll) {
     return true;
   }
   if (!context) {
     return false;
   }
-  return trimmed
-    .split(',')
-    .map((segment) => segment.trim())
-    .filter(Boolean)
-    .includes(context.toLowerCase());
+  return flag.contexts.has(context.toLowerCase());
 }
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,12 +10,18 @@ export { AngularSSRService, DEFAULT_CACHE_EXPIRATION_TIME } from './angular-ssr.
 // Cache implementations
 export { InMemoryCacheStorage } from './cache/in-memory-cache-storage';
 export { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
+
+// Debug logging
+export { ANGULAR_SSR_DEBUG_ENV, DebugLogger, isDebugEnabled } from './debug-logger';
+
 // Interfaces
 export type {
+  AngularEngineType,
   AngularSSRModuleAsyncOptions,
   AngularSSRModuleOptions,
   CacheOptions,
   ErrorHandler,
+  SkipPath,
   StaticProvider,
 } from './interfaces/angular-ssr-module-options.interface';
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,11 @@ export { AngularSSRMiddleware } from './angular-ssr.middleware';
 export { AngularSSRModule } from './angular-ssr.module';
 
 // Service
-export { AngularSSRService, DEFAULT_CACHE_EXPIRATION_TIME } from './angular-ssr.service';
+export {
+  AngularSSRService,
+  DEFAULT_CACHE_EXPIRATION_TIME,
+  type SSRRequestContext,
+} from './angular-ssr.service';
 
 // Cache implementations
 export { InMemoryCacheStorage } from './cache/in-memory-cache-storage';
@@ -28,5 +32,9 @@ export type {
 export type { CacheKeyGenerator } from './interfaces/cache-key-generator.interface';
 export type { CacheEntry, CacheStorage } from './interfaces/cache-storage.interface';
 
-// Tokens
-export { ANGULAR_SSR_OPTIONS, REQUEST, RESPONSE } from './tokens';
+// Module-internal token
+export { ANGULAR_SSR_OPTIONS } from './tokens';
+
+// Re-export Angular's request-injection tokens so consumers don't need a
+// separate `@angular/core` import in their NestJS module wiring.
+export { REQUEST, REQUEST_CONTEXT } from '@angular/core';

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -117,13 +117,11 @@ export interface AngularSSRModuleOptions {
   engineType?: AngularEngineType;
 
   /**
-   * Route path(s) on which the SSR middleware will run.
+   * Route path(s) on which the SSR middleware will run. Default
+   * `'{/*splat}'` is the NestJS 11 / Express 5 / path-to-regexp v8 splat
+   * pattern that matches both root `/` and every nested path.
    *
-   * Default `'*splat'` (NestJS 11 / path-to-regexp 8 wildcard). For NestJS 10
-   * with path-to-regexp 6, supply `'*'` (or any other syntax your version
-   * accepts) explicitly.
-   *
-   * @default '*splat'
+   * @default '{/*splat}'
    */
   renderPath?: string | string[];
 
@@ -133,7 +131,7 @@ export interface AngularSSRModuleOptions {
    *
    * Same wildcard caveats apply as for `renderPath`.
    *
-   * @default '*splat'
+   * @default '{/*splat}'
    */
   rootStaticPath?: string;
 

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -39,13 +39,34 @@ export interface CacheOptions {
 }
 
 /**
- * Error handler function type for SSR rendering errors
+ * Error handler function type for SSR rendering errors.
+ * If the handler writes a response (e.g. res.status(500).send(...)) the
+ * middleware detects res.headersSent and stops the chain. If it does not,
+ * the original error is forwarded to next() so Nest can handle it.
  */
 export type ErrorHandler = (error: Error, request: Request, response: Response) => void;
 
 /**
- * Angular SSR engine type
- * Supports AngularAppEngine, AngularNodeAppEngine, or CommonEngine
+ * Angular SSR engine variant.
+ *
+ * Used as an explicit override when constructor-name detection is unreliable
+ * (e.g. in heavily minified production bundles where class names are mangled).
+ *
+ * - `common` — `CommonEngine` from `@angular/ssr/node`
+ * - `node-app` — `AngularNodeAppEngine` from `@angular/ssr/node`
+ * - `app` — `AngularAppEngine` from `@angular/ssr`
+ */
+export type AngularEngineType = 'common' | 'node-app' | 'app';
+
+/**
+ * Path-skip rule for the SSR middleware. Paths matching any of these are
+ * passed straight to next() without invoking SSR.
+ */
+export type SkipPath = string | RegExp;
+
+/**
+ * Angular SSR engine instance type.
+ * Supports AngularAppEngine, AngularNodeAppEngine, or CommonEngine.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AngularSSREngine = any;
@@ -55,72 +76,103 @@ export type AngularSSREngine = any;
  */
 export interface AngularSSRModuleOptions {
   /**
-   * Path to the directory containing the client bundle (Angular browser build)
-   * This is typically 'dist/{app-name}/browser'
+   * Path to the directory containing the client bundle (Angular browser build).
+   * Typically `dist/{app-name}/browser`.
    */
   browserDistFolder: string;
 
   /**
-   * Path to the server bundle bootstrap function
-   * This should be the path to the server entry point
+   * Path to the server bundle directory.
    */
   serverDistFolder?: string;
 
   /**
-   * Path to the index.html template file
-   * @default '{browserDistFolder}/index.server.html'
+   * Path to the index.html template file.
+   * @default `{browserDistFolder}/index.server.html`
    */
   indexHtml?: string;
 
   /**
-   * The Angular bootstrap function from the server bundle
-   * This is the default export from your Angular SSR server entry
-   * For CommonEngine: returns the CommonEngine instance
-   * For AngularAppEngine/AngularNodeAppEngine: returns the engine instance
+   * Returns the Angular SSR engine instance.
+   *
+   * For `CommonEngine`: return the `CommonEngine` instance.
+   * For `AngularAppEngine` / `AngularNodeAppEngine`: return the engine instance.
    */
   bootstrap: () => Promise<AngularSSREngine>;
 
   /**
-   * The Angular application bootstrap function for CommonEngine
-   * Required when using CommonEngine
-   * This should be the bootstrapApplication function from your main.server.ts
+   * Application bootstrap function used by `CommonEngine`.
+   * Should be the `bootstrapApplication`-returning default export from
+   * `main.server.ts`.
+   *
+   * Ignored for `AngularAppEngine` and `AngularNodeAppEngine`.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   angularBootstrap?: () => Promise<any>;
 
   /**
-   * Route path to render the Angular app
-   * @default '*'
+   * Explicit engine type override. When set, disables runtime detection.
+   * Recommended for production builds where class names may be minified.
+   */
+  engineType?: AngularEngineType;
+
+  /**
+   * Route path(s) on which the SSR middleware will run.
+   *
+   * Default `'*splat'` (NestJS 11 / path-to-regexp 8 wildcard). For NestJS 10
+   * with path-to-regexp 6, supply `'*'` (or any other syntax your version
+   * accepts) explicitly.
+   *
+   * @default '*splat'
    */
   renderPath?: string | string[];
 
   /**
-   * Root path for serving static files
-   * @default '*'
+   * Route path on which `express.static()` will serve files from
+   * `browserDistFolder`.
+   *
+   * Same wildcard caveats apply as for `renderPath`.
+   *
+   * @default '*splat'
    */
   rootStaticPath?: string;
 
   /**
-   * Additional providers to be included during server-side rendering
+   * Paths to skip in the SSR middleware (passed straight to `next()`).
+   * Useful for API prefixes that share the wildcard render path.
+   *
+   * @default ['/api']
+   */
+  skipPaths?: SkipPath[];
+
+  /**
+   * Additional providers to be included during server-side rendering.
+   * Only applied to the `CommonEngine` path.
    */
   extraProviders?: StaticProvider[];
 
   /**
-   * Whether to inline critical CSS to reduce render-blocking
+   * Whether to inline critical CSS to reduce render-blocking.
+   * Only applied to the `CommonEngine` path; `AngularAppEngine`/
+   * `AngularNodeAppEngine` handle this internally per their own config.
+   *
    * @default true
    */
   inlineCriticalCss?: boolean;
 
   /**
-   * Cache configuration
-   * Set to false to disable caching, true for default caching,
-   * or provide custom cache options
+   * Cache configuration. `false` disables caching, `true` uses defaults,
+   * or pass `CacheOptions` for fine-grained control.
+   *
+   * Only `GET` and `HEAD` requests are ever cached.
+   *
    * @default true
    */
   cache?: boolean | CacheOptions;
 
   /**
-   * Custom error handler for rendering errors
+   * Custom error handler for rendering errors. See `ErrorHandler` for the
+   * contract on writing responses.
    */
   errorHandler?: ErrorHandler;
 }

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -1,19 +1,14 @@
 import type { CacheKeyGenerator } from './cache-key-generator.interface';
 import type { CacheStorage } from './cache-storage.interface';
+import type { StaticProvider as AngularStaticProvider } from '@angular/core';
 import type { Request, Response } from 'express';
 
 /**
- * Provider type compatible with Angular's StaticProvider
+ * Provider type alias for Angular's `StaticProvider`. Re-exported so
+ * consumers can write `extraProviders` without a separate `@angular/core`
+ * import.
  */
-export interface StaticProvider {
-  provide: unknown;
-  useValue?: unknown;
-  useClass?: unknown;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  useFactory?: Function;
-  deps?: unknown[];
-  multi?: boolean;
-}
+export type StaticProvider = AngularStaticProvider;
 
 /**
  * Cache configuration options for Angular SSR
@@ -36,6 +31,14 @@ export interface CacheOptions {
    * @default URL-based key generator
    */
   keyGenerator?: CacheKeyGenerator;
+
+  /**
+   * Maximum entries kept by the default `InMemoryCacheStorage` before LRU
+   * eviction kicks in. Ignored when a custom `storage` is supplied.
+   *
+   * @default 1024
+   */
+  maxEntries?: number;
 }
 
 /**

--- a/lib/tokens.spec.ts
+++ b/lib/tokens.spec.ts
@@ -1,33 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { ANGULAR_SSR_OPTIONS, REQUEST, RESPONSE } from './tokens';
+import { ANGULAR_SSR_OPTIONS } from './tokens';
 
 describe('Tokens', () => {
-  describe('REQUEST', () => {
-    it('should be a string token', () => {
-      expect(typeof REQUEST).toBe('string');
-    });
-
-    it('should have the correct value', () => {
-      expect(REQUEST).toBe('ANGULAR_SSR_REQUEST');
-    });
-  });
-
-  describe('RESPONSE', () => {
-    it('should be a string token', () => {
-      expect(typeof RESPONSE).toBe('string');
-    });
-
-    it('should have the correct value', () => {
-      expect(RESPONSE).toBe('ANGULAR_SSR_RESPONSE');
-    });
-  });
-
   describe('ANGULAR_SSR_OPTIONS', () => {
-    it('should be a Symbol', () => {
+    it('is a unique symbol', () => {
       expect(typeof ANGULAR_SSR_OPTIONS).toBe('symbol');
     });
 
-    it('should have descriptive symbol name', () => {
+    it('has a descriptive symbol name', () => {
       expect(ANGULAR_SSR_OPTIONS.toString()).toBe('Symbol(ANGULAR_SSR_OPTIONS)');
     });
   });

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,23 +1,12 @@
 import type { AngularSSRModuleOptions } from './interfaces';
 
 /**
- * Injection token for Express Request object
- * Use with @Inject(REQUEST) in your Angular components (server-side only)
+ * Internal injection token for module options.
  *
- * This is a string token that can be used with both NestJS and Angular DI systems.
- */
-export const REQUEST = 'ANGULAR_SSR_REQUEST';
-
-/**
- * Injection token for Express Response object
- * Use with @Inject(RESPONSE) in your Angular components (server-side only)
- *
- * This is a string token that can be used with both NestJS and Angular DI systems.
- */
-export const RESPONSE = 'ANGULAR_SSR_RESPONSE';
-
-/**
- * Internal injection token for module options
+ * For per-render request / response access in Angular components, use
+ * `@angular/core`'s `REQUEST` and `REQUEST_CONTEXT` tokens (re-exported from
+ * the package entry for convenience). The library wires both tokens for
+ * every engine path.
  */
 export const ANGULAR_SSR_OPTIONS = Symbol('ANGULAR_SSR_OPTIONS');
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "homepage": "https://github.com/Lexmata/nestjs-angular-ssr#readme",
   "peerDependencies": {
     "@angular/ssr": ">=19.0.0",
-    "@nestjs/common": ">=10.0.0",
-    "@nestjs/core": ">=10.0.0",
+    "@nestjs/common": ">=11.0.0",
+    "@nestjs/core": ">=11.0.0",
     "express": ">=4.18.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": ">=7.0.0"
@@ -54,10 +54,10 @@
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@eslint/js": "^10.0.1",
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
-    "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/testing": "^10.0.0",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/testing": "^11.0.0",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.0.0",
@@ -83,7 +83,7 @@
   },
   "packageManager": "pnpm@10.20.0",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.0.0"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist",
-    "tokens"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",
@@ -42,14 +41,20 @@
   },
   "homepage": "https://github.com/Lexmata/nestjs-angular-ssr#readme",
   "peerDependencies": {
+    "@angular/core": ">=19.0.0",
+    "@angular/platform-server": ">=19.0.0",
     "@angular/ssr": ">=19.0.0",
     "@nestjs/common": ">=11.0.0",
     "@nestjs/core": ">=11.0.0",
     "express": ">=4.18.0",
     "reflect-metadata": ">=0.1.13",
-    "rxjs": ">=7.0.0"
+    "rxjs": ">=7.0.0",
+    "zone.js": ">=0.15.0"
   },
   "devDependencies": {
+    "@angular/compiler": "^19.2.21",
+    "@angular/core": "^19.0.0",
+    "@angular/platform-server": "^19.0.0",
     "@angular/ssr": "^19.0.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
@@ -79,7 +84,8 @@
     "rxjs": "^7.8.0",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.57.1",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "zone.js": "^0.15.0"
   },
   "packageManager": "pnpm@10.20.0",
   "engines": {
@@ -89,10 +95,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js"
-    },
-    "./tokens": {
-      "types": "./dist/tokens.d.ts",
-      "require": "./dist/tokens.js"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     devDependencies:
+      '@angular/compiler':
+        specifier: ^19.2.21
+        version: 19.2.21
+      '@angular/core':
+        specifier: ^19.0.0
+        version: 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-server':
+        specifier: ^19.0.0
+        version: 19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/ssr':
         specifier: ^19.0.0
-        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
+        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
       '@commitlint/cli':
         specifier: ^19.0.0
         version: 19.8.1(@types/node@22.19.3)(typescript@5.9.3)
@@ -98,12 +107,15 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.3)(terser@5.44.1)
+      zone.js:
+        specifier: ^0.15.0
+        version: 0.15.1
 
   example:
     dependencies:
       '@angular/ssr':
         specifier: ^19.0.0
-        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
+        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
       '@lexmata/nestjs-angular-ssr':
         specifier: workspace:*
         version: link:..
@@ -170,6 +182,10 @@ packages:
       '@angular/core': 19.2.17
       rxjs: ^6.5.3 || ^7.4.0
 
+  '@angular/compiler@19.2.21':
+    resolution: {integrity: sha512-lLWXzeLPk+4kkXKpy/h0OAie3V2YImpDrzluufJ0xR8OlCffJNpanfBjm7R4tOZB7i0ONIxhsD67Z0oRhEECCQ==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+
   '@angular/core@19.2.17':
     resolution: {integrity: sha512-nVu0ryxfiXUZ9M+NV21TY+rJZkPXTYo9U0aJb19hvByPpG+EvuujXUOgpulz6vxIzGy7pz/znRa+K9kxuuC+yQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
@@ -187,6 +203,16 @@ packages:
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
+
+  '@angular/platform-server@19.2.21':
+    resolution: {integrity: sha512-urk7XYX/C4HbE/ZeqcSXnAvbat8CdVXBF2oz0CiVY8V8ENYPi1OFRXbxnmGPtHo4YNWwcycomddcKcSNzRdE+A==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/common': 19.2.21
+      '@angular/compiler': 19.2.21
+      '@angular/core': 19.2.21
+      '@angular/platform-browser': 19.2.21
+      rxjs: ^6.5.3 || ^7.4.0
 
   '@angular/router@19.2.17':
     resolution: {integrity: sha512-B3Vk+E8UHQwg06WEjGuvYaKNiIXxjHN9pN8S+hDE8xwRgIS5ojEwS94blEvsGQ4QsIja6WjZMOfDUBUPlgUSuA==}
@@ -1967,6 +1993,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -1982,10 +2009,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -3332,6 +3361,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xhr2@0.2.1:
+    resolution: {integrity: sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==}
+    engines: {node: '>= 6'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3409,6 +3442,10 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
+  '@angular/compiler@19.2.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)':
     dependencies:
       rxjs: 7.8.2
@@ -3421,6 +3458,16 @@ snapshots:
       '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
       tslib: 2.8.1
 
+  '@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler': 19.2.21
+      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      xhr2: 0.2.1
+
   '@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
@@ -3429,12 +3476,14 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ssr@19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))':
+  '@angular/ssr@19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))':
     dependencies:
       '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/router': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       tslib: 2.8.1
+    optionalDependencies:
+      '@angular/platform-server': 19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6767,6 +6816,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  xhr2@0.2.1: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,17 +21,17 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
       '@nestjs/common':
-        specifier: ^10.0.0
-        version: 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^11.0.0
+        version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
       '@nestjs/testing':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(@nestjs/platform-express@10.4.20)
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -585,6 +585,19 @@ packages:
       class-validator:
         optional: true
 
+  '@nestjs/common@11.1.19':
+    resolution: {integrity: sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/core@10.4.20':
     resolution: {integrity: sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==}
     peerDependencies:
@@ -602,29 +615,58 @@ packages:
       '@nestjs/websockets':
         optional: true
 
+  '@nestjs/core@11.1.19':
+    resolution: {integrity: sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+
   '@nestjs/platform-express@10.4.20':
     resolution: {integrity: sha512-rh97mX3rimyf4xLMLHuTOBKe6UD8LOJ14VlJ1F/PTd6C6ZK9Ak6EHuJvdaGcSFQhd3ZMBh3I6CuujKGW9pNdIg==}
     peerDependencies:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
 
+  '@nestjs/platform-express@11.1.19':
+    resolution: {integrity: sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+
   '@nestjs/schematics@10.2.3':
     resolution: {integrity: sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==}
     peerDependencies:
       typescript: '>=4.8.2'
 
-  '@nestjs/testing@10.4.20':
-    resolution: {integrity: sha512-nMkRDukDKskdPruM6EsgMq7yJua+CPZM6I6FrLP8yXw8BiVSPv9Nm0CtcGGwt3kgZF9hfxKjGqLjsvVBsv6Vfw==}
+  '@nestjs/testing@11.1.19':
+    resolution: {integrity: sha512-/UFNWXvPEdu4v4DlC5oWLbGKmD27LehLK06b8oLzs6D6lf4vAQTdST8LRAXBadyMUQnVEQWMuBo3CtAVtlfXtQ==}
     peerDependencies:
-      '@nestjs/common': ^10.0.0
-      '@nestjs/core': ^10.0.0
-      '@nestjs/microservices': ^10.0.0
-      '@nestjs/platform-express': ^10.0.0
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
     peerDependenciesMeta:
       '@nestjs/microservices':
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nuxt/opencollective@0.4.1':
+    resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
+    engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
+    hasBin: true
 
   '@nuxtjs/opencollective@0.3.2':
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
@@ -754,6 +796,10 @@ packages:
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
 
   '@tokenizer/token@0.3.0':
@@ -1061,6 +1107,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1189,6 +1239,10 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1374,9 +1428,17 @@ packages:
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -1401,6 +1463,10 @@ packages:
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
@@ -1417,6 +1483,10 @@ packages:
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.2.0:
@@ -1744,6 +1814,10 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -1787,6 +1861,10 @@ packages:
     resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
     engines: {node: '>=18'}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1798,6 +1876,10 @@ packages:
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -1836,6 +1918,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -1974,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2061,6 +2151,9 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -2188,6 +2281,10 @@ packages:
     resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
     engines: {node: '>=18.0.0'}
 
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
+
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
@@ -2266,6 +2363,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -2276,6 +2377,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2292,9 +2397,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -2345,6 +2458,10 @@ packages:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
 
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
+
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
@@ -2371,6 +2488,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -2416,6 +2537,9 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -2504,6 +2628,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2568,6 +2695,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -2582,6 +2713,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -2653,6 +2788,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -2706,12 +2845,20 @@ packages:
     resolution: {integrity: sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2990,6 +3137,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -3177,6 +3328,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3643,6 +3797,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -3659,6 +3825,20 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nuxt/opencollective': 0.4.1
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+
   '@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
     dependencies:
       '@nestjs/common': 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -3667,6 +3847,18 @@ snapshots:
       cors: 2.8.5
       express: 4.21.2
       multer: 2.0.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cors: 2.8.6
+      express: 5.2.1
+      multer: 2.1.1
+      path-to-regexp: 8.4.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3682,13 +3874,17 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(@nestjs/platform-express@10.4.20)':
+  '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)':
     dependencies:
-      '@nestjs/common': 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+
+  '@nuxt/opencollective@0.4.1':
+    dependencies:
+      consola: 3.4.2
 
   '@nuxtjs/opencollective@0.3.2':
     dependencies:
@@ -3775,6 +3971,13 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fflate: 0.8.2
+      token-types: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
       token-types: 6.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4145,6 +4348,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4284,6 +4492,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4468,9 +4690,13 @@ snapshots:
 
   consola@2.15.3: {}
 
+  consola@3.4.2: {}
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
+
+  content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
 
@@ -4493,6 +4719,8 @@ snapshots:
 
   cookie-signature@1.0.7: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.1: {}
 
   cookie@0.7.2: {}
@@ -4504,6 +4732,11 @@ snapshots:
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
@@ -4960,6 +5193,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -4999,6 +5265,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.1
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5024,6 +5299,17 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.2
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5072,6 +5358,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -5208,6 +5496,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -5296,6 +5588,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@3.0.0: {}
 
@@ -5419,6 +5713,8 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  load-esm@1.0.3: {}
+
   loader-runner@4.3.1: {}
 
   locate-path@6.0.0:
@@ -5488,6 +5784,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
@@ -5495,6 +5793,8 @@ snapshots:
   meow@12.1.1: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -5507,9 +5807,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -5553,6 +5859,13 @@ snapshots:
       type-is: 1.6.18
       xtend: 4.0.2
 
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+
   mute-stream@0.0.8: {}
 
   mute-stream@1.0.0: {}
@@ -5566,6 +5879,8 @@ snapshots:
   natural-orderby@5.0.0: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -5596,6 +5911,10 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -5686,6 +6005,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -5729,6 +6050,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -5747,6 +6072,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   readable-stream@3.6.2:
@@ -5830,6 +6162,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-async@2.4.1: {}
 
   run-async@3.0.0: {}
@@ -5909,6 +6251,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -5919,6 +6277,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6174,6 +6541,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typedarray@0.0.6: {}
 
   typescript-eslint@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
@@ -6392,6 +6765,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
 

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -1,6 +1,0 @@
-/**
- * Re-export tokens from the main library
- * Import from '@lexmata/nestjs-angular-ssr/tokens' in your Angular components
- */
-export { REQUEST, RESPONSE } from '../lib/tokens';
-

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,4 +1,0 @@
-{
-  "main": "../dist/tokens.js",
-  "types": "../dist/tokens.d.ts"
-}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Use the forks pool so a Nest bootstrap exception during e2e tests
+    // surfaces as a normal test failure instead of crashing a worker thread.
+    pool: 'forks',
     include: ['lib/**/*.spec.ts'],
     coverage: {
       provider: 'v8',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // Use the forks pool so a Nest bootstrap exception during e2e tests
-    // surfaces as a normal test failure instead of crashing a worker thread.
     pool: 'forks',
     include: ['lib/**/*.spec.ts'],
     coverage: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,10 @@
+// `@angular/ssr` and `@angular/platform-server` require zone.js to be loaded
+// before any of their classes are imported. `@angular/compiler` is needed
+// because the library imports a partial-compiled bundle (`@angular/common`'s
+// PlatformLocation) which falls back to JIT compilation in the test process.
+// Both must precede any Angular import.
+import 'zone.js/node';
+import '@angular/compiler';
 import { vi } from 'vitest';
 
 // Mock NestJS Logger to silence all log output during tests


### PR DESCRIPTION
## Summary

Deep-dive audit + remediation of `@lexmata/nestjs-angular-ssr`. The unit suite passed at 100/100 but was mocking out everything that actually mattered — a real NestJS boot revealed several defects that contradicted the README's advertised behaviour or broke under realistic conditions.

> Targeted at `main` because there's no remote `develop` branch on this repo yet. Happy to rebase onto `develop` if one gets pushed before merge.

## Commits

1. **`chore(deps): bump @nestjs to v11 and relax node baseline to 20`** — baseline move for the rest of the work.
2. **`fix(ssr): correct request/response wiring, error handling, and routing`** — the core remediation.
3. **`refactor(ssr): simplify per code-review and switch to express 5 splat`** — post-review cleanup; default wildcard becomes `'{/*splat}'`.
4. **`feat(ssr): runtime angular imports, instanceof detection, lru cache`** — adds `@angular/core`/`@angular/platform-server`/`@angular/ssr`/`zone.js` as runtime deps, switches engine detection to `instanceof`, adopts Angular's `REQUEST`/`REQUEST_CONTEXT` tokens, and bounds the default cache with LRU eviction.

## Behaviour fixes

- **`REQUEST` / `REQUEST_CONTEXT` injection actually works now.** Under the old code the module exported string tokens but never registered them as providers. CommonEngine now receives them per-render; the `AngularAppEngine`/`AngularNodeAppEngine` paths forward `{ request, response }` as the engine's `requestContext`. Tokens re-exported from `@angular/core` so consumers don't need a separate Angular import.
- **Middleware error path no longer hangs.** Errors thrown before the service's inner try/catch (e.g. engine not yet initialised) used to bypass the user's `errorHandler` and return silently, leaving the request to time out. Middleware now invokes the handler itself and only forwards to `next()` if the response wasn't written.
- **`inlineCriticalCss` now does something.** Was declared, documented, ignored.
- **Wildcard default is now `'{/*splat}'`** — NestJS 11 / Express 5 / path-to-regexp v8 native splat. Bare `'*'` threw `Missing parameter name` under v11.
- **Engine detection uses `instanceof`** against the real `@angular/ssr` classes instead of `constructor.name === '...'`, which breaks under minification.
- **Method-aware caching + middleware skip.** `POST /foo` and `GET /foo` no longer collide in the cache; SSR doesn't run for `POST`/`PUT`/`PATCH`/`DELETE`/`OPTIONS`.
- **Cache key preserves URL case** (`/Users/Alice` and `/users/alice` no longer share a slot); only the host is lower-cased per RFC 3986.
- **`InMemoryCacheStorage` is bounded** to 1024 entries by default with LRU eviction. New `CacheOptions.maxEntries` knob.

## Routing & DI

- `AngularSSRMiddleware` is now declared as a provider in both `forRoot` and `forRootAsync` and uses an explicit `@Inject(AngularSSRService)`. NestJS 11 (and any bundler that drops `design:paramtypes` metadata like esbuild/swc) couldn't resolve the bare-typed param before.
- Static `AngularSSRModule.options` state removed. Options flow through DI into the module instance; `configure()` reads from `this`.
- New `engineType` option (`'common' | 'node-app' | 'app'`) for minified production builds where the `instanceof` check would fail.
- New `skipPaths` option (string prefixes or `RegExp`) replacing the hardcoded `/api` skip (kept as the default).

## Debug logger

- `ANGULAR_SSR_DEBUG` env flag toggles verbose tracing across the module, service, and middleware. Warnings/errors always emit; `log`/`debug`/`verbose` gate.
- Global toggle (`1`/`true`/`yes`/`on`/`*`) or per-context allow-list (`AngularSSRMiddleware,AngularSSRService`). Re-read on every call — but memoised against the raw env string, so per-request cost is a single env read + `Set` lookup.
- Hot-path template-string allocation is guarded by `logger.enabled()` so debug mode has no cost when off.
- `DebugLogger`, `isDebugEnabled`, `ANGULAR_SSR_DEBUG_ENV` re-exported for downstream reuse.

## Tests

- **New e2e spec** (`lib/angular-ssr.e2e.spec.ts`) boots a real NestJS 11 app over Express and issues real HTTP requests. Catches regressions the mocked unit suite can't: this is the test that exposed the wildcard incompatibility and the DI-provider bug.
- Engine mocks use `Object.create(Class.prototype)` to pass the new `instanceof` checks without paying for a full Angular bootstrap.
- CommonEngine + AngularNodeAppEngine paths were previously untested; both have full coverage now, including `REQUEST`/`REQUEST_CONTEXT` wiring, `inlineCriticalCss` propagation, and `engineType` overrides.
- Five new LRU cases (overflow eviction, recency promotion via `get`, refresh on duplicate `set`, unbounded mode, default-cap headroom).
- Vitest uses the `forks` pool so Nest bootstrap exceptions surface as normal test failures.

## Verification

- `pnpm test` — **164/164 passing** across 8 files (incl. e2e).
- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
- `pnpm build` — clean.
- `pnpm format:check` — clean.
- `pnpm test:coverage` — **100% statements / 100% lines / 100% functions / 99.42% branches**. The missed branch is a defensive `for...of` exhaustion path in the LRU evictor that can't hit at runtime.

## Breaking changes

- **peerDependencies** now require `@nestjs/common >=11`, `@nestjs/core >=11`, plus new `@angular/core >=19`, `@angular/platform-server >=19`, `zone.js >=0.15`.
- **`engines.node`** relaxed from `>=24` to `>=20`.
- **Removed** the custom `'ANGULAR_SSR_REQUEST'` / `'ANGULAR_SSR_RESPONSE'` string tokens and the `./tokens` subpath export. Consumers should import `REQUEST` / `REQUEST_CONTEXT` from `@lexmata/nestjs-angular-ssr` (which re-exports them from `@angular/core`) and use `REQUEST_CONTEXT` for `{ request, response }` access.

## Test plan

- [x] `pnpm test` (unit + e2e)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `pnpm test:coverage` (≥90% thresholds configured in vitest, actual 99.42% branches)
- [ ] Smoke-test against `lexmata-app-frontend` / `lexmata-marketing` before tagging a release