### PR TITLE
chore: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn.lock
 *.tgz
 .npmrc
 
+.worktrees/


### PR DESCRIPTION
Follow-up to #1.

Lexmata convention develops feature/bugfix/hotfix branches in `.worktrees/<branch-name>/` at the repo root. Without this gitignore entry, those checkouts and their `node_modules` trees pollute `git status` of the primary working directory.

No tracked content under `.worktrees/` today, so this change is purely prospective.

## Test plan

- [x] `git check-ignore .worktrees/` returns a match after the change