### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

First non-prerelease cut of `@lexmata/nestjs-angular-ssr`. Drops the `-beta.1` pre-release suffix so `pnpm publish` publishes under the `latest` dist-tag.

All scoped work for the initial release has already landed on `main`:
- #1 — SSR integration defects, NestJS 11 peer, Angular runtime deps, LRU cache, debug logger
- #2 — `.worktrees/` gitignore

## What's in 0.1.0

- Angular SSR integration for Angular 19+ and NestJS 11.
- Supports `CommonEngine`, `AngularNodeAppEngine`, and `AngularAppEngine` with `instanceof`-based detection and an explicit `engineType` override.
- Per-render `REQUEST` / `REQUEST_CONTEXT` injection wired for every engine path; tokens re-exported from `@angular/core` through the package entry.
- LRU-bounded in-memory cache with method-aware, case-preserving keys; HEAD collapses into GET. Pluggable `CacheStorage` / `CacheKeyGenerator`.
- `skipPaths` for middleware bypass, `inlineCriticalCss` honoured on CommonEngine, graceful error handler wiring that no longer hangs the response.
- `ANGULAR_SSR_DEBUG` env flag gates verbose per-context tracing.
- 167 tests across 8 files including a real-NestJS e2e that boots over Express; 100% line/function/statement coverage, 99.45% branch.

## Release mechanics

1. Merge this PR into `main` (squash).
2. Back-merge `main` into `develop` so the version bump lives on both branches (per git-flow).
3. Tag `v0.1.0` on `main` and run `pnpm publish` from `main`.

## Test plan

- [x] `pnpm install` — no lockfile churn
- [x] Tests/lint/typecheck/build all green on `develop` at `f1ad17d`
- [ ] `pnpm publish --dry-run` from `main` after merge (tarball contents already verified for `0.1.0-beta.1`; the version string is the only diff)