### PR TITLE
chore: refresh .npmignore after tokens/ removal

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
-# Source files (dist is included)
+# Belt-and-braces ignore file. `package.json` "files" already whitelists
+# `dist`, so this mostly exists to defend against someone dropping that
+# field in the future — keep it in sync when moving files around.
+
+# Source files (dist is what we publish)
 lib/
-tokens/index.ts
 
 # Tests
 **/*.spec.ts
@@ -10,6 +13,12 @@ vitest.setup.*
 
 # Example application
 example/
+
+# GitHub Pages docs site
+docs/
+
+# Developer worktrees
+.worktrees/
 
 # Config files
 tsconfig.json
@@ -37,6 +46,7 @@ commitlint.config.*
 
 # Package managers
 pnpm-lock.yaml
+pnpm-workspace.yaml
 yarn.lock
 package-lock.json
 


### PR DESCRIPTION
Follow-up to #1 / #5.

`.npmignore` still listed `tokens/index.ts`, a path deleted in #1 when the `./tokens` subpath export was dropped. While refreshing that line:

- Added `docs/` — GitHub Pages site, shouldn't be in the tarball
- Added `.worktrees/` — Lexmata workflow artefacts
- Added `pnpm-workspace.yaml` — never needed by consumers
- Added a header comment clarifying that `package.json` `"files"` is the authoritative whitelist; this file is belt-and-braces.

Tarball contents unchanged — verified via `pnpm pack`: 55 files, 26.8 kB. No user-visible change.

## Test plan

- [x] `pnpm pack` produces the same 55-file tarball as `main@80e6c3c`
- [x] `package.json` `"files": ["dist"]` still dominates — removing dist from `.npmignore` would have no effect either way