### PR TITLE
chore(publish): mark scoped package as public

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Unblocks the first real \`pnpm publish\`. Tried publishing \`0.1.0\` from \`main\` just now and got:

\`\`\`
npm error code E402
npm error 402 Payment Required - PUT https://registry.npmjs.org/@lexmata%2fnestjs-angular-ssr - You must sign up for private packages
\`\`\`

Scoped packages default to \`access: "restricted"\` on npm — which requires a paid org. Adding \`publishConfig.access: "public"\` to \`package.json\` fixes it permanently (no need to pass \`--access=public\` on every publish).

## Test plan

- [x] \`pnpm pack\` produces the same 55-file tarball (\`publishConfig\` doesn't affect packing)
- [ ] \`pnpm publish\` from \`main\` after this + version bump to \`0.1.1\` succeeds

Note: \`0.1.0\` was never published (the 402 happened *after* the version bump PR #5 landed), so re-publishing \`0.1.0\` after this merges should work. If npm rejects the re-use of \`0.1.0\`, we'll cut \`0.1.1\`.