### PR TITLE
feat(ssr): add post-render HTML transform pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,20 +311,21 @@ NODE_ENV=production
 
 ### `forRoot()` Options
 
-| Property            | Type                               | Default                                 | Description                                                                            |
-| ------------------- | ---------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
-| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                            |
-| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                           |
-| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                    |
-| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                        |
-| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds) |
-| `renderPath`        | `string \| string[]?`              | `'{/*splat}'`                           | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes)      |
-| `rootStaticPath`    | `string?`                          | `'{/*splat}'`                           | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes)        |
-| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                |
-| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                  |
-| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                   |
-| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                         |
-| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                          |
+| Property            | Type                               | Default                                 | Description                                                                                                 |
+| ------------------- | ---------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                                                 |
+| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                                                |
+| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                                         |
+| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                                             |
+| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds)                      |
+| `renderPath`        | `string \| string[]?`              | `'{/*splat}'`                           | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes)                           |
+| `rootStaticPath`    | `string?`                          | `'{/*splat}'`                           | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes)                             |
+| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                                     |
+| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                                       |
+| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                                        |
+| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                                              |
+| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                                               |
+| `afterRender`       | `AfterRenderTransform[]?`          | `[]`                                    | Post-render HTML transform pipeline — see [Post-render transform pipeline](#post-render-transform-pipeline) |
 
 ### Wildcard routes
 
@@ -421,6 +422,56 @@ export class AppModule {}
 ```
 
 `@nestjs/cache-manager` and `cache-manager` are declared as **optional** peer dependencies — install them only if you use `NestCacheStorage`. TTL is delegated to cache-manager (so `CacheModule.ttl` wins); the service's `cache.expiresIn` is still forwarded as the per-entry TTL so both stay in sync.
+
+## Post-render transform pipeline
+
+`options.afterRender` is an ordered list of functions that rewrite the HTML emitted by the Angular engine before it's cached or sent. Each transform sees the output of the previous one, can be sync or async, and receives an `AfterRenderContext` with the Express request, response, and full URL.
+
+Use cases: injecting a CSP nonce, adding tracking tags, minifying, rewriting asset paths, embedding request-id headers in meta tags.
+
+### Example: CSP nonce
+
+A classic use of the pipeline is stamping a per-request nonce on every `<script>` / `<style>` tag so your CSP header can enforce `script-src 'nonce-...'`. Because nonces MUST be unique per response, this example disables caching for nonce-bearing routes.
+
+```typescript
+import { randomBytes } from 'node:crypto';
+import { Module } from '@nestjs/common';
+import type { AfterRenderTransform } from '@lexmata/nestjs-angular-ssr';
+import { AngularSSRModule } from '@lexmata/nestjs-angular-ssr';
+
+const cspNonce: AfterRenderTransform = (html, { response }) => {
+  const nonce = randomBytes(16).toString('base64');
+  response.setHeader(
+    'Content-Security-Policy',
+    `script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'`,
+  );
+  return html
+    .replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`)
+    .replace(/<style(?![^>]*\snonce=)/g, `<style nonce="${nonce}"`);
+};
+
+@Module({
+  imports: [
+    AngularSSRModule.forRoot({
+      browserDistFolder: '...',
+      bootstrap: () => getAngularAppEngine(),
+      afterRender: [cspNonce],
+      cache: false, // nonces must be per-request; don't cache stale ones
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Ordering and caching
+
+Transforms run **before** the cache write, so cached HTML reflects the whole pipeline. That's the right default for transforms that produce stable output (minification, path rewrites, static tracking tags). For per-request output like nonces or user-specific content:
+
+- Disable caching entirely (`cache: false`), or
+- Scope the caching to routes that don't need per-request transforms via `skipPaths`, or
+- Write a placeholder into the HTML and replace it via a response header / cookie rather than inlining the value.
+
+If any transform throws, the configured `errorHandler` is invoked and no further transforms run; the response falls through to `next(error)` if no handler is set.
 
 ## Custom Cache Storage
 

--- a/README.md
+++ b/README.md
@@ -440,14 +440,15 @@ import type { AfterRenderTransform } from '@lexmata/nestjs-angular-ssr';
 import { AngularSSRModule } from '@lexmata/nestjs-angular-ssr';
 
 const cspNonce: AfterRenderTransform = (html, { response }) => {
-  const nonce = randomBytes(16).toString('base64');
+  const nonce = randomBytes(16).toString('base64url');
   response.setHeader(
     'Content-Security-Policy',
     `script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'`,
   );
-  return html
-    .replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`)
-    .replace(/<style(?![^>]*\snonce=)/g, `<style nonce="${nonce}"`);
+  // Single pass, alternation over both tags. The negative lookahead skips
+  // tags that already carry a nonce (avoids duplicating the attribute if
+  // another transform stamped one earlier in the pipeline).
+  return html.replace(/<(script|style)(?![^>]*\snonce=)/g, `<$1 nonce="${nonce}"`);
 };
 
 @Module({

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -548,6 +548,158 @@ describe('AngularSSRService', () => {
     });
   });
 
+  describe('afterRender pipeline', () => {
+    let engine: ReturnType<typeof createAppEngine>;
+
+    beforeEach(() => {
+      engine = createAppEngine();
+      mockOptions = { ...mockOptions, bootstrap: vi.fn().mockResolvedValue(engine) };
+    });
+
+    const mockAngularResponse = (html: string) => ({
+      text: vi.fn().mockResolvedValue(html),
+    });
+
+    it('returns the engine output unchanged when afterRender is unset', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('<html>raw</html>'));
+      service = new AngularSSRService(mockOptions);
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe(
+        '<html>raw</html>',
+      );
+    });
+
+    it('applies a single transform to the rendered HTML', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('<html>raw</html>'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [(html) => html.replace('raw', 'cooked')],
+      });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe(
+        '<html>cooked</html>',
+      );
+    });
+
+    it('pipes transforms in declaration order', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('A'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [(html) => `${html}B`, (html) => `${html}C`, (html) => `${html}D`],
+      });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe('ABCD');
+    });
+
+    it('awaits async transforms', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('start'));
+      // A thenable (not a bare value) is returned so the service's `await`
+      // in the pipeline actually has to suspend the microtask queue.
+      const asyncTransform = async (html: string): Promise<string> => `${html}-async`;
+      service = new AngularSSRService({ ...mockOptions, afterRender: [asyncTransform] });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe('start-async');
+    });
+
+    it('passes request, response, and url in the context', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('x'));
+      const capture = vi.fn().mockImplementation((html: string) => html);
+      service = new AngularSSRService({ ...mockOptions, afterRender: [capture] });
+      await service.onModuleInit();
+
+      const request = createMockRequest({ originalUrl: '/products/42' });
+      const response = createMockResponse();
+      await service.render(request, response);
+
+      expect(capture).toHaveBeenCalledWith('x', {
+        request,
+        response,
+        url: expect.stringContaining('/products/42'),
+      });
+    });
+
+    it('caches the post-transform HTML, not the raw engine output', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('raw'));
+      const transform = vi.fn().mockImplementation((html: string) => `${html}-cooked`);
+      service = new AngularSSRService({ ...mockOptions, afterRender: [transform] });
+      await service.onModuleInit();
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      expect(await service.render(req, res)).toBe('raw-cooked');
+      // Second call hits the cache; transform does NOT run again.
+      expect(await service.render(req, res)).toBe('raw-cooked');
+
+      expect(transform).toHaveBeenCalledTimes(1);
+      expect(engine.handle).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips transforms when the engine returns null', async () => {
+      engine.handle.mockResolvedValue(null);
+      const transform = vi.fn();
+      service = new AngularSSRService({ ...mockOptions, afterRender: [transform] });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBeNull();
+      expect(transform).not.toHaveBeenCalled();
+    });
+
+    it('routes transform throws through the configured errorHandler', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      const boom = new Error('transform failed');
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          () => {
+            throw boom;
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+      const result = await service.render(request, response);
+
+      expect(errorHandler).toHaveBeenCalledWith(boom, request, response);
+      expect(result).toBeNull();
+    });
+
+    it('aborts the pipeline at the first thrown transform', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const boom = new Error('stop');
+      const second = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [
+          () => {
+            throw boom;
+          },
+          second,
+        ],
+      });
+      await service.onModuleInit();
+
+      await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(boom);
+      expect(second).not.toHaveBeenCalled();
+    });
+
+    it('treats an empty afterRender array as a no-op', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      service = new AngularSSRService({ ...mockOptions, afterRender: [] });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe('ok');
+    });
+  });
+
   describe('error handling', () => {
     let engine: ReturnType<typeof createAppEngine>;
 

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -560,9 +560,12 @@ describe('AngularSSRService', () => {
       text: vi.fn().mockResolvedValue(html),
     });
 
-    it('returns the engine output unchanged when afterRender is unset', async () => {
+    it.each([
+      ['afterRender is unset', undefined],
+      ['afterRender is an empty array', []],
+    ])('returns the engine output unchanged when %s', async (_label, afterRender) => {
       engine.handle.mockResolvedValue(mockAngularResponse('<html>raw</html>'));
-      service = new AngularSSRService(mockOptions);
+      service = new AngularSSRService({ ...mockOptions, afterRender });
       await service.onModuleInit();
 
       expect(await service.render(createMockRequest(), createMockResponse())).toBe(
@@ -689,14 +692,6 @@ describe('AngularSSRService', () => {
 
       await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(boom);
       expect(second).not.toHaveBeenCalled();
-    });
-
-    it('treats an empty afterRender array as a no-op', async () => {
-      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
-      service = new AngularSSRService({ ...mockOptions, afterRender: [] });
-      await service.onModuleInit();
-
-      expect(await service.render(createMockRequest(), createMockResponse())).toBe('ok');
     });
   });
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -12,6 +12,7 @@ import { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
 import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type {
+  AfterRenderContext,
   AngularSSRModuleOptions,
   CacheKeyGenerator,
   CacheOptions,
@@ -138,10 +139,15 @@ export class AngularSSRService implements OnModuleInit {
       }
     }
 
+    // URL is computed once per render and passed through. Previously it
+    // was recomputed by `renderWithCommonEngine`, `applyAfterRender`, and
+    // the catch-block log — three calls per cacheable miss under the
+    // common configuration.
+    const url = this.getRequestUrl(request);
+
     try {
-      const rendered = await this.invokeEngine(this.angularEngine, request, response);
-      const html =
-        rendered === null ? null : await this.applyAfterRender(rendered, request, response);
+      const rendered = await this.invokeEngine(this.angularEngine, request, response, url);
+      const html = await this.applyAfterRender(rendered, { request, response, url });
 
       if (cacheKey !== null && html) {
         await this.cacheStorage.set(cacheKey, {
@@ -152,7 +158,7 @@ export class AngularSSRService implements OnModuleInit {
 
       return html;
     } catch (error) {
-      this.logger.error(`Error rendering: ${this.getRequestUrl(request)}`, error);
+      this.logger.error(`Error rendering: ${url}`, error);
 
       if (this.options.errorHandler) {
         this.options.errorHandler(error as Error, request, response);
@@ -167,9 +173,10 @@ export class AngularSSRService implements OnModuleInit {
     engine: AngularEngine,
     request: Request,
     response: Response,
+    url: string,
   ): Promise<string | null> {
     if (this.isCommonEngine(engine)) {
-      return await this.renderWithCommonEngine(engine, request, response);
+      return await this.renderWithCommonEngine(engine, request, response, url);
     }
     const angularRequest: Request | globalThis.Request = this.isNodeAppEngine(engine)
       ? request
@@ -181,6 +188,7 @@ export class AngularSSRService implements OnModuleInit {
     engine: CommonEngine,
     request: Request,
     response: Response,
+    url: string,
   ): Promise<string | null> {
     const documentFilePath =
       this.options.indexHtml ?? join(this.options.browserDistFolder, 'index.server.html');
@@ -204,7 +212,7 @@ export class AngularSSRService implements OnModuleInit {
       bootstrap,
       documentFilePath,
       publicPath: this.options.browserDistFolder,
-      url: this.getRequestUrl(request),
+      url,
       inlineCriticalCss: this.options.inlineCriticalCss ?? true,
       providers,
     });
@@ -230,17 +238,18 @@ export class AngularSSRService implements OnModuleInit {
    * Run the configured `afterRender` pipeline against the engine's HTML
    * output. Each transform sees the previous transform's result; the
    * final value is what the service caches (if cacheable) and returns.
+   *
+   * Null input (the "engine produced no response" path) short-circuits —
+   * transforms never see `null`.
    */
   private async applyAfterRender(
-    html: string,
-    request: Request,
-    response: Response,
-  ): Promise<string> {
+    html: string | null,
+    context: AfterRenderContext,
+  ): Promise<string | null> {
     const transforms = this.options.afterRender;
-    if (!transforms?.length) {
+    if (html === null || !transforms?.length) {
       return html;
     }
-    const context = { request, response, url: this.getRequestUrl(request) };
     let current = html;
     for (const transform of transforms) {
       current = await transform(current, context);

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -139,7 +139,9 @@ export class AngularSSRService implements OnModuleInit {
     }
 
     try {
-      const html = await this.invokeEngine(this.angularEngine, request, response);
+      const rendered = await this.invokeEngine(this.angularEngine, request, response);
+      const html =
+        rendered === null ? null : await this.applyAfterRender(rendered, request, response);
 
       if (cacheKey !== null && html) {
         await this.cacheStorage.set(cacheKey, {
@@ -222,6 +224,28 @@ export class AngularSSRService implements OnModuleInit {
       return null;
     }
     return await angularResponse.text();
+  }
+
+  /**
+   * Run the configured `afterRender` pipeline against the engine's HTML
+   * output. Each transform sees the previous transform's result; the
+   * final value is what the service caches (if cacheable) and returns.
+   */
+  private async applyAfterRender(
+    html: string,
+    request: Request,
+    response: Response,
+  ): Promise<string> {
+    const transforms = this.options.afterRender;
+    if (!transforms?.length) {
+      return html;
+    }
+    const context = { request, response, url: this.getRequestUrl(request) };
+    let current = html;
+    for (const transform of transforms) {
+      current = await transform(current, context);
+    }
+    return current;
   }
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,8 @@ export { ANGULAR_SSR_DEBUG_ENV, DebugLogger, isDebugEnabled } from './debug-logg
 
 // Interfaces
 export type {
+  AfterRenderContext,
+  AfterRenderTransform,
   AngularEngineType,
   AngularSSRModuleAsyncOptions,
   AngularSSRModuleOptions,

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -68,6 +68,39 @@ export type AngularEngineType = 'common' | 'node-app' | 'app';
 export type SkipPath = string | RegExp;
 
 /**
+ * Per-render context passed to `AfterRenderTransform` functions.
+ */
+export interface AfterRenderContext {
+  request: Request;
+  response: Response;
+  /**
+   * The full request URL (protocol + host + originalUrl). Provided so
+   * transforms don't have to reconstruct it from the Express request.
+   */
+  url: string;
+}
+
+/**
+ * A single stage in the post-render HTML transform pipeline. Receives the
+ * HTML emitted by the Angular engine (or the previous transform) and
+ * returns the transformed HTML.
+ *
+ * Transforms may be synchronous or return a `Promise`. They run in the
+ * order they're declared in `afterRender`. If any transform throws, the
+ * configured `errorHandler` is invoked and no further transforms run.
+ *
+ * **Cache interaction**: transforms run BEFORE the cache write, so the
+ * cached HTML is the post-transform output. If a transform produces
+ * per-request output (e.g. a CSP nonce), disable caching for that route
+ * via `skipPaths` or `cache: false`, or inject a stable placeholder and
+ * replace it on the way out via the `response` (set cookie, header, etc.).
+ */
+export type AfterRenderTransform = (
+  html: string,
+  context: AfterRenderContext,
+) => string | Promise<string>;
+
+/**
  * Angular SSR engine instance type.
  * Supports AngularAppEngine, AngularNodeAppEngine, or CommonEngine.
  */
@@ -176,6 +209,17 @@ export interface AngularSSRModuleOptions {
    * contract on writing responses.
    */
   errorHandler?: ErrorHandler;
+
+  /**
+   * Ordered pipeline of post-render HTML transforms. Each transform sees
+   * the output of the previous one and can mutate the HTML string (inject
+   * a CSP nonce, add tracking tags, minify, rewrite asset paths, etc.).
+   *
+   * Transforms run BEFORE the cache write, so cached HTML reflects the
+   * transforms. If a transform produces per-request output that shouldn't
+   * be cached (e.g. a CSP nonce), disable caching for affected routes.
+   */
+  afterRender?: AfterRenderTransform[];
 }
 
 /**

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -81,19 +81,9 @@ export interface AfterRenderContext {
 }
 
 /**
- * A single stage in the post-render HTML transform pipeline. Receives the
- * HTML emitted by the Angular engine (or the previous transform) and
- * returns the transformed HTML.
- *
- * Transforms may be synchronous or return a `Promise`. They run in the
- * order they're declared in `afterRender`. If any transform throws, the
- * configured `errorHandler` is invoked and no further transforms run.
- *
- * **Cache interaction**: transforms run BEFORE the cache write, so the
- * cached HTML is the post-transform output. If a transform produces
- * per-request output (e.g. a CSP nonce), disable caching for that route
- * via `skipPaths` or `cache: false`, or inject a stable placeholder and
- * replace it on the way out via the `response` (set cookie, header, etc.).
+ * A single stage in the post-render HTML transform pipeline. See the
+ * `afterRender` option on `AngularSSRModuleOptions` for pipeline
+ * semantics and cache interaction.
  */
 export type AfterRenderTransform = (
   html: string,


### PR DESCRIPTION
## Summary

Adds `AngularSSRModuleOptions.afterRender` — an ordered array of transform functions that rewrite the HTML emitted by the Angular engine before it's cached or sent. Each transform sees the previous one's output, can be sync or async, and receives an `AfterRenderContext` with the Express request, response, and full URL.

Primary motivating use case: CSP nonce injection. A classic pattern is to stamp a per-request `nonce="..."` on every `<script>` / `<style>` and set a matching `Content-Security-Policy` response header. Other uses: HTML minification, asset-path rewriting, tracking tags, request-id meta tags.

## Usage (nonce example)

```typescript
import { randomBytes } from 'node:crypto';
import type { AfterRenderTransform } from '@lexmata/nestjs-angular-ssr';

const cspNonce: AfterRenderTransform = (html, { response }) => {
  const nonce = randomBytes(16).toString('base64');
  response.setHeader(
    'Content-Security-Policy',
    `script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'`,
  );
  return html
    .replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`)
    .replace(/<style(?![^>]*\snonce=)/g, `<style nonce="${nonce}"`);
};

AngularSSRModule.forRoot({
  browserDistFolder: '...',
  bootstrap: () => getAngularAppEngine(),
  afterRender: [cspNonce],
  cache: false, // nonces must be per-request — don't cache stale ones
});
```

## Pipeline semantics

- Transforms run **after** the engine returns HTML but **before** the cache write — cached HTML reflects the full pipeline. That's the right default for transforms that produce stable output (minification, path rewrites). Per-request transforms (nonces, user-specific content) must disable caching for affected routes via `cache: false` or `skipPaths`.
- Transforms run sequentially. An async transform blocks the next.
- A throw aborts the pipeline, routes through the configured `errorHandler` if set, and otherwise propagates to the middleware's error path (unchanged behaviour).
- A `null` engine output (the miss path) skips the pipeline entirely — transforms never see `null`.

## What's shipped

- New `AfterRenderTransform` type + `AfterRenderContext` type, both re-exported from the package entry.
- New `afterRender` option on `AngularSSRModuleOptions`.
- `AngularSSRService.applyAfterRender()` private method runs the pipeline.
- README adds a dedicated "Post-render transform pipeline" section with the nonce example and an explicit note on cache interaction.
- 10 new unit tests for pipeline ordering, async transforms, context shape, cache interaction, null-output bypass, error-handler routing, and first-throw abort.

## Verification

- 177 tests passing across 8 files (42 → 52 on the service spec).
- Lint / typecheck / build / format:check all clean.
- Coverage: 100% statements / functions / lines, 99.48% branches.

## Test plan

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `pnpm test:coverage`
- [ ] Wire the nonce example into a downstream app and verify the CSP header + `nonce="..."` attribute actually survive Angular hydration