### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
   schedule:
     - cron: '0 6 * * 1' # Weekly on Monday at 6am UTC
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 permissions:
   contents: read

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
-# Source files (dist is included)
+# Belt-and-braces ignore file. `package.json` "files" already whitelists
+# `dist`, so this mostly exists to defend against someone dropping that
+# field in the future — keep it in sync when moving files around.
+
+# Source files (dist is what we publish)
 lib/
-tokens/index.ts
 
 # Tests
 **/*.spec.ts
@@ -10,6 +13,12 @@ vitest.setup.*
 
 # Example application
 example/
+
+# GitHub Pages docs site
+docs/
+
+# Developer worktrees
+.worktrees/
 
 # Config files
 tsconfig.json
@@ -37,6 +46,7 @@ commitlint.config.*
 
 # Package managers
 pnpm-lock.yaml
+pnpm-workspace.yaml
 yarn.lock
 package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,33 @@ if (isDebugEnabled('AngularSSRService')) {
 
 The exported `DebugLogger` class can be reused in your own SSR-related code if you want a logger that obeys the same flag.
 
+## Using `@nestjs/cache-manager` as the cache backend
+
+If the host app already wires `CacheModule` from `@nestjs/cache-manager` (for Redis, memcached, multi-store setups, or just to get the metrics/tracing the default in-memory store lacks), the library ships a `NestCacheStorage` adapter that plugs the `Cache` service straight into `CacheOptions.storage`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { Cache, CacheModule } from '@nestjs/cache-manager';
+import { AngularSSRModule, NestCacheStorage } from '@lexmata/nestjs-angular-ssr';
+
+@Module({
+  imports: [
+    CacheModule.register({ ttl: 60_000, isGlobal: true }),
+    AngularSSRModule.forRootAsync({
+      inject: [Cache],
+      useFactory: (cache: Cache) => ({
+        browserDistFolder: '...',
+        bootstrap: () => getAngularAppEngine(),
+        cache: { storage: new NestCacheStorage(cache) },
+      }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+`@nestjs/cache-manager` and `cache-manager` are declared as **optional** peer dependencies — install them only if you use `NestCacheStorage`. TTL is delegated to cache-manager (so `CacheModule.ttl` wins); the service's `cache.expiresIn` is still forwarded as the per-entry TTL so both stay in sync.
+
 ## Custom Cache Storage
 
 Implement the `CacheStorage` interface for custom caching solutions (e.g., Redis):

--- a/README.md
+++ b/README.md
@@ -311,20 +311,21 @@ NODE_ENV=production
 
 ### `forRoot()` Options
 
-| Property            | Type                               | Default                                 | Description                                                                            |
-| ------------------- | ---------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
-| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                            |
-| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                           |
-| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                    |
-| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                        |
-| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds) |
-| `renderPath`        | `string \| string[]?`              | `'{/*splat}'`                           | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes)      |
-| `rootStaticPath`    | `string?`                          | `'{/*splat}'`                           | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes)        |
-| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                |
-| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                  |
-| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                   |
-| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                         |
-| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                          |
+| Property            | Type                               | Default                                 | Description                                                                                                 |
+| ------------------- | ---------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `browserDistFolder` | `string`                           | **required**                            | Path to the Angular browser build directory                                                                 |
+| `bootstrap`         | `() => Promise<AngularAppEngine>`  | **required**                            | Function that returns the Angular SSR engine                                                                |
+| `serverDistFolder`  | `string?`                          | -                                       | Path to the server bundle directory                                                                         |
+| `indexHtml`         | `string?`                          | `{browserDistFolder}/index.server.html` | Path to the index.html template                                                                             |
+| `engineType`        | `'common' \| 'node-app' \| 'app'?` | -                                       | Explicit engine override; bypasses runtime detection (recommended for minified builds)                      |
+| `renderPath`        | `string \| string[]?`              | `'{/*splat}'`                           | Route path(s) to render the Angular app — see [Wildcard routes](#wildcard-routes)                           |
+| `rootStaticPath`    | `string?`                          | `'{/*splat}'`                           | Path pattern for serving static files — see [Wildcard routes](#wildcard-routes)                             |
+| `skipPaths`         | `(string \| RegExp)[]?`            | `['/api']`                              | Paths the SSR middleware passes through to `next()` (e.g. API prefixes)                                     |
+| `extraProviders`    | `StaticProvider[]?`                | -                                       | Additional providers — applied to `CommonEngine` only                                                       |
+| `inlineCriticalCss` | `boolean?`                         | `true`                                  | Inline critical CSS — applied to `CommonEngine` only                                                        |
+| `cache`             | `boolean \| CacheOptions?`         | `true`                                  | Cache configuration (only `GET`/`HEAD` cached)                                                              |
+| `errorHandler`      | `ErrorHandler?`                    | -                                       | Custom error handler function                                                                               |
+| `afterRender`       | `AfterRenderTransform[]?`          | `[]`                                    | Post-render HTML transform pipeline — see [Post-render transform pipeline](#post-render-transform-pipeline) |
 
 ### Wildcard routes
 
@@ -421,6 +422,57 @@ export class AppModule {}
 ```
 
 `@nestjs/cache-manager` and `cache-manager` are declared as **optional** peer dependencies — install them only if you use `NestCacheStorage`. TTL is delegated to cache-manager (so `CacheModule.ttl` wins); the service's `cache.expiresIn` is still forwarded as the per-entry TTL so both stay in sync.
+
+## Post-render transform pipeline
+
+`options.afterRender` is an ordered list of functions that rewrite the HTML emitted by the Angular engine before it's cached or sent. Each transform sees the output of the previous one, can be sync or async, and receives an `AfterRenderContext` with the Express request, response, and full URL.
+
+Use cases: injecting a CSP nonce, adding tracking tags, minifying, rewriting asset paths, embedding request-id headers in meta tags.
+
+### Example: CSP nonce
+
+A classic use of the pipeline is stamping a per-request nonce on every `<script>` / `<style>` tag so your CSP header can enforce `script-src 'nonce-...'`. Because nonces MUST be unique per response, this example disables caching for nonce-bearing routes.
+
+```typescript
+import { randomBytes } from 'node:crypto';
+import { Module } from '@nestjs/common';
+import type { AfterRenderTransform } from '@lexmata/nestjs-angular-ssr';
+import { AngularSSRModule } from '@lexmata/nestjs-angular-ssr';
+
+const cspNonce: AfterRenderTransform = (html, { response }) => {
+  const nonce = randomBytes(16).toString('base64url');
+  response.setHeader(
+    'Content-Security-Policy',
+    `script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'`,
+  );
+  // Single pass, alternation over both tags. The negative lookahead skips
+  // tags that already carry a nonce (avoids duplicating the attribute if
+  // another transform stamped one earlier in the pipeline).
+  return html.replace(/<(script|style)(?![^>]*\snonce=)/g, `<$1 nonce="${nonce}"`);
+};
+
+@Module({
+  imports: [
+    AngularSSRModule.forRoot({
+      browserDistFolder: '...',
+      bootstrap: () => getAngularAppEngine(),
+      afterRender: [cspNonce],
+      cache: false, // nonces must be per-request; don't cache stale ones
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Ordering and caching
+
+Transforms run **before** the cache write, so cached HTML reflects the whole pipeline. That's the right default for transforms that produce stable output (minification, path rewrites, static tracking tags). For per-request output like nonces or user-specific content:
+
+- Disable caching entirely (`cache: false`), or
+- Scope the caching to routes that don't need per-request transforms via `skipPaths`, or
+- Write a placeholder into the HTML and replace it via a response header / cookie rather than inlining the value.
+
+If any transform throws, the configured `errorHandler` is invoked and no further transforms run; the response falls through to `next(error)` if no handler is set.
 
 ## Custom Cache Storage
 

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -548,6 +548,153 @@ describe('AngularSSRService', () => {
     });
   });
 
+  describe('afterRender pipeline', () => {
+    let engine: ReturnType<typeof createAppEngine>;
+
+    beforeEach(() => {
+      engine = createAppEngine();
+      mockOptions = { ...mockOptions, bootstrap: vi.fn().mockResolvedValue(engine) };
+    });
+
+    const mockAngularResponse = (html: string) => ({
+      text: vi.fn().mockResolvedValue(html),
+    });
+
+    it.each([
+      ['afterRender is unset', undefined],
+      ['afterRender is an empty array', []],
+    ])('returns the engine output unchanged when %s', async (_label, afterRender) => {
+      engine.handle.mockResolvedValue(mockAngularResponse('<html>raw</html>'));
+      service = new AngularSSRService({ ...mockOptions, afterRender });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe(
+        '<html>raw</html>',
+      );
+    });
+
+    it('applies a single transform to the rendered HTML', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('<html>raw</html>'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [(html) => html.replace('raw', 'cooked')],
+      });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe(
+        '<html>cooked</html>',
+      );
+    });
+
+    it('pipes transforms in declaration order', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('A'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [(html) => `${html}B`, (html) => `${html}C`, (html) => `${html}D`],
+      });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe('ABCD');
+    });
+
+    it('awaits async transforms', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('start'));
+      // A thenable (not a bare value) is returned so the service's `await`
+      // in the pipeline actually has to suspend the microtask queue.
+      const asyncTransform = async (html: string): Promise<string> => `${html}-async`;
+      service = new AngularSSRService({ ...mockOptions, afterRender: [asyncTransform] });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBe('start-async');
+    });
+
+    it('passes request, response, and url in the context', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('x'));
+      const capture = vi.fn().mockImplementation((html: string) => html);
+      service = new AngularSSRService({ ...mockOptions, afterRender: [capture] });
+      await service.onModuleInit();
+
+      const request = createMockRequest({ originalUrl: '/products/42' });
+      const response = createMockResponse();
+      await service.render(request, response);
+
+      expect(capture).toHaveBeenCalledWith('x', {
+        request,
+        response,
+        url: expect.stringContaining('/products/42'),
+      });
+    });
+
+    it('caches the post-transform HTML, not the raw engine output', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('raw'));
+      const transform = vi.fn().mockImplementation((html: string) => `${html}-cooked`);
+      service = new AngularSSRService({ ...mockOptions, afterRender: [transform] });
+      await service.onModuleInit();
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      expect(await service.render(req, res)).toBe('raw-cooked');
+      // Second call hits the cache; transform does NOT run again.
+      expect(await service.render(req, res)).toBe('raw-cooked');
+
+      expect(transform).toHaveBeenCalledTimes(1);
+      expect(engine.handle).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips transforms when the engine returns null', async () => {
+      engine.handle.mockResolvedValue(null);
+      const transform = vi.fn();
+      service = new AngularSSRService({ ...mockOptions, afterRender: [transform] });
+      await service.onModuleInit();
+
+      expect(await service.render(createMockRequest(), createMockResponse())).toBeNull();
+      expect(transform).not.toHaveBeenCalled();
+    });
+
+    it('routes transform throws through the configured errorHandler', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      const boom = new Error('transform failed');
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          () => {
+            throw boom;
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const request = createMockRequest();
+      const response = createMockResponse();
+      const result = await service.render(request, response);
+
+      expect(errorHandler).toHaveBeenCalledWith(boom, request, response);
+      expect(result).toBeNull();
+    });
+
+    it('aborts the pipeline at the first thrown transform', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const boom = new Error('stop');
+      const second = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [
+          () => {
+            throw boom;
+          },
+          second,
+        ],
+      });
+      await service.onModuleInit();
+
+      await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(boom);
+      expect(second).not.toHaveBeenCalled();
+    });
+  });
+
   describe('error handling', () => {
     let engine: ReturnType<typeof createAppEngine>;
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -12,6 +12,7 @@ import { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
 import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type {
+  AfterRenderContext,
   AngularSSRModuleOptions,
   CacheKeyGenerator,
   CacheOptions,
@@ -138,8 +139,15 @@ export class AngularSSRService implements OnModuleInit {
       }
     }
 
+    // URL is computed once per render and passed through. Previously it
+    // was recomputed by `renderWithCommonEngine`, `applyAfterRender`, and
+    // the catch-block log — three calls per cacheable miss under the
+    // common configuration.
+    const url = this.getRequestUrl(request);
+
     try {
-      const html = await this.invokeEngine(this.angularEngine, request, response);
+      const rendered = await this.invokeEngine(this.angularEngine, request, response, url);
+      const html = await this.applyAfterRender(rendered, { request, response, url });
 
       if (cacheKey !== null && html) {
         await this.cacheStorage.set(cacheKey, {
@@ -150,7 +158,7 @@ export class AngularSSRService implements OnModuleInit {
 
       return html;
     } catch (error) {
-      this.logger.error(`Error rendering: ${this.getRequestUrl(request)}`, error);
+      this.logger.error(`Error rendering: ${url}`, error);
 
       if (this.options.errorHandler) {
         this.options.errorHandler(error as Error, request, response);
@@ -165,9 +173,10 @@ export class AngularSSRService implements OnModuleInit {
     engine: AngularEngine,
     request: Request,
     response: Response,
+    url: string,
   ): Promise<string | null> {
     if (this.isCommonEngine(engine)) {
-      return await this.renderWithCommonEngine(engine, request, response);
+      return await this.renderWithCommonEngine(engine, request, response, url);
     }
     const angularRequest: Request | globalThis.Request = this.isNodeAppEngine(engine)
       ? request
@@ -179,6 +188,7 @@ export class AngularSSRService implements OnModuleInit {
     engine: CommonEngine,
     request: Request,
     response: Response,
+    url: string,
   ): Promise<string | null> {
     const documentFilePath =
       this.options.indexHtml ?? join(this.options.browserDistFolder, 'index.server.html');
@@ -202,7 +212,7 @@ export class AngularSSRService implements OnModuleInit {
       bootstrap,
       documentFilePath,
       publicPath: this.options.browserDistFolder,
-      url: this.getRequestUrl(request),
+      url,
       inlineCriticalCss: this.options.inlineCriticalCss ?? true,
       providers,
     });
@@ -222,6 +232,29 @@ export class AngularSSRService implements OnModuleInit {
       return null;
     }
     return await angularResponse.text();
+  }
+
+  /**
+   * Run the configured `afterRender` pipeline against the engine's HTML
+   * output. Each transform sees the previous transform's result; the
+   * final value is what the service caches (if cacheable) and returns.
+   *
+   * Null input (the "engine produced no response" path) short-circuits —
+   * transforms never see `null`.
+   */
+  private async applyAfterRender(
+    html: string | null,
+    context: AfterRenderContext,
+  ): Promise<string | null> {
+    const transforms = this.options.afterRender;
+    if (html === null || !transforms?.length) {
+      return html;
+    }
+    let current = html;
+    for (const transform of transforms) {
+      current = await transform(current, context);
+    }
+    return current;
   }
 
   /**

--- a/lib/cache/expiry.ts
+++ b/lib/cache/expiry.ts
@@ -1,0 +1,9 @@
+import type { CacheEntry } from '../interfaces';
+
+/**
+ * Returns true when the entry's `expiresAt` has passed. Shared by every
+ * `CacheStorage` implementation so "expired" always means the same thing.
+ */
+export function isExpired(entry: CacheEntry, now: number = Date.now()): boolean {
+  return now > entry.expiresAt;
+}

--- a/lib/cache/in-memory-cache-storage.spec.ts
+++ b/lib/cache/in-memory-cache-storage.spec.ts
@@ -97,8 +97,10 @@ describe('InMemoryCacheStorage', () => {
   });
 
   describe('delete()', () => {
-    it('should return false for non-existent key', () => {
-      expect(storage.delete('non-existent')).toBe(false);
+    it('should return true for non-existent key (matches CacheStorage contract)', () => {
+      // CacheStorage.delete() returns true on successful completion,
+      // not "true iff a key existed." Missing keys are not an error.
+      expect(storage.delete('non-existent')).toBe(true);
     });
 
     it('should delete entry and return true', () => {

--- a/lib/cache/in-memory-cache-storage.ts
+++ b/lib/cache/in-memory-cache-storage.ts
@@ -1,3 +1,4 @@
+import { isExpired } from './expiry';
 import type { CacheEntry, CacheStorage } from '../interfaces';
 
 /**
@@ -32,7 +33,7 @@ export class InMemoryCacheStorage implements CacheStorage {
     if (!entry) {
       return undefined;
     }
-    if (Date.now() > entry.expiresAt) {
+    if (isExpired(entry)) {
       this.cache.delete(key);
       return undefined;
     }
@@ -50,16 +51,27 @@ export class InMemoryCacheStorage implements CacheStorage {
     this.evictIfOverCapacity();
   }
 
+  /**
+   * @returns always `true` — matches `cache-manager` / Redis semantics
+   * where a missing key is not an error.
+   */
   delete(key: string): boolean {
-    return this.cache.delete(key);
+    this.cache.delete(key);
+    return true;
   }
 
   clear(): void {
     this.cache.clear();
   }
 
+  /**
+   * Read-only existence check. Does NOT evict stale entries — pairs with
+   * `CacheStorage.has()`'s contract, so callers using it as a predicate
+   * don't trigger unexpected writes.
+   */
   has(key: string): boolean {
-    return this.get(key) !== undefined;
+    const entry = this.cache.get(key);
+    return entry !== undefined && !isExpired(entry);
   }
 
   /**
@@ -75,7 +87,7 @@ export class InMemoryCacheStorage implements CacheStorage {
   prune(): void {
     const now = Date.now();
     for (const [key, entry] of this.cache.entries()) {
-      if (now > entry.expiresAt) {
+      if (isExpired(entry, now)) {
         this.cache.delete(key);
       }
     }

--- a/lib/cache/index.ts
+++ b/lib/cache/index.ts
@@ -1,2 +1,3 @@
 export * from './in-memory-cache-storage';
+export * from './nest-cache-storage';
 export * from './url-cache-key-generator';

--- a/lib/cache/nest-cache-storage.spec.ts
+++ b/lib/cache/nest-cache-storage.spec.ts
@@ -1,0 +1,148 @@
+import { createCache } from 'cache-manager';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NestCacheStorage } from './nest-cache-storage';
+import type { CacheEntry } from '../interfaces';
+import type { Cache } from '@nestjs/cache-manager';
+
+// A real `cache-manager` instance is used rather than a hand-rolled mock so
+// the adapter's expectations about the Cache API stay honest against the
+// library it's adapting. The default in-memory store is fine — we never
+// leave the process.
+
+const fresh = (content: string, ttlMs = 60_000): CacheEntry => ({
+  content,
+  expiresAt: Date.now() + ttlMs,
+});
+
+describe('NestCacheStorage', () => {
+  let cache: Cache;
+  let storage: NestCacheStorage;
+
+  beforeEach(() => {
+    // cache-manager v7 returns a bare `Cache` instance; that matches the
+    // token @nestjs/cache-manager re-exports.
+    cache = createCache() as unknown as Cache;
+    storage = new NestCacheStorage(cache);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('get()', () => {
+    it('returns undefined for a missing key', async () => {
+      expect(await storage.get('missing')).toBeUndefined();
+    });
+
+    it('returns the stored entry', async () => {
+      const entry = fresh('<html>ok</html>');
+      await storage.set('k', entry);
+
+      const result = await storage.get('k');
+      expect(result?.content).toBe('<html>ok</html>');
+    });
+
+    it('treats a past expiresAt as a miss even if the store has the value', async () => {
+      // Bypass the adapter's own clock to seed a stale entry — cache-manager
+      // would otherwise have evicted it on its own TTL too.
+      const stale: CacheEntry = { content: '<html>old</html>', expiresAt: Date.now() - 1 };
+      await cache.set('k', stale);
+
+      expect(await storage.get('k')).toBeUndefined();
+    });
+
+    it('fire-and-forget-evicts the stale entry so a subsequent read is still a miss', async () => {
+      const stale: CacheEntry = { content: '<html>old</html>', expiresAt: Date.now() - 1 };
+      await cache.set('k', stale);
+
+      await storage.get('k');
+      // The del() is intentionally not awaited so the render path
+      // doesn't pay a second RTT on Redis-backed stores. Flush the
+      // microtask queue before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(await cache.get('k')).toBeUndefined();
+    });
+
+    it('ignores errors from the fire-and-forget eviction', async () => {
+      const stale: CacheEntry = { content: '<html>old</html>', expiresAt: Date.now() - 1 };
+      await cache.set('k', stale);
+      vi.spyOn(cache, 'del').mockRejectedValueOnce(new Error('boom'));
+
+      // No unhandled rejection, no throw.
+      expect(await storage.get('k')).toBeUndefined();
+    });
+  });
+
+  describe('set()', () => {
+    it('stores an entry retrievable via get()', async () => {
+      await storage.set('k', fresh('<html>ok</html>'));
+      const result = await storage.get('k');
+      expect(result?.content).toBe('<html>ok</html>');
+    });
+
+    it('derives cache-manager TTL from expiresAt', async () => {
+      const setSpy = vi.spyOn(cache, 'set');
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      await storage.set('k', { content: 'x', expiresAt: now + 5000 });
+
+      expect(setSpy).toHaveBeenCalledWith('k', expect.any(Object), 5000);
+    });
+
+    it('passes undefined when expiresAt is in the past so cache-manager uses its default TTL', async () => {
+      const setSpy = vi.spyOn(cache, 'set');
+      await storage.set('k', { content: 'x', expiresAt: Date.now() - 1 });
+
+      expect(setSpy).toHaveBeenCalledWith('k', expect.any(Object), undefined);
+    });
+  });
+
+  describe('delete()', () => {
+    it('returns true after deleting a stored key', async () => {
+      await storage.set('k', fresh('<html>ok</html>'));
+      expect(await storage.delete('k')).toBe(true);
+      expect(await storage.get('k')).toBeUndefined();
+    });
+
+    it('returns true for a missing key (matches CacheStorage contract)', async () => {
+      // CacheStorage.delete() returns true on successful completion,
+      // not "true iff a key existed." See `cache-storage.interface.ts`.
+      expect(await storage.delete('nope')).toBe(true);
+    });
+  });
+
+  describe('clear()', () => {
+    it('empties the store', async () => {
+      await storage.set('a', fresh('A'));
+      await storage.set('b', fresh('B'));
+
+      await storage.clear();
+
+      expect(await storage.get('a')).toBeUndefined();
+      expect(await storage.get('b')).toBeUndefined();
+    });
+  });
+
+  describe('has()', () => {
+    it('returns false for a missing key', async () => {
+      expect(await storage.has('missing')).toBe(false);
+    });
+
+    it('returns true for a valid key', async () => {
+      await storage.set('k', fresh('ok'));
+      expect(await storage.has('k')).toBe(true);
+    });
+
+    it('returns false for a stale key without deleting it', async () => {
+      const stale: CacheEntry = { content: 'old', expiresAt: Date.now() - 1 };
+      await cache.set('k', stale);
+      const delSpy = vi.spyOn(cache, 'del');
+
+      expect(await storage.has('k')).toBe(false);
+      expect(delSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/cache/nest-cache-storage.ts
+++ b/lib/cache/nest-cache-storage.ts
@@ -1,0 +1,68 @@
+import { isExpired } from './expiry';
+import type { CacheEntry, CacheStorage } from '../interfaces';
+import type { Cache } from '@nestjs/cache-manager';
+
+/**
+ * `CacheStorage` adapter that delegates to a `@nestjs/cache-manager`
+ * `Cache` service. See the README's "Using `@nestjs/cache-manager` as
+ * the cache backend" section for usage.
+ *
+ * TTL is delegated to cache-manager (the backend decides when an entry
+ * is evicted); the service's `cache.expiresIn` is still forwarded as
+ * the per-entry TTL so the two configs stay in sync.
+ */
+export class NestCacheStorage implements CacheStorage {
+  constructor(private readonly cache: Cache) {}
+
+  async get(key: string): Promise<CacheEntry | undefined> {
+    const stored = await this.cache.get<CacheEntry>(key);
+    if (!stored) {
+      return undefined;
+    }
+    if (isExpired(stored)) {
+      // Fire-and-forget — cache-manager's own TTL should have evicted
+      // this already; the explicit del() is belt-and-braces for keyv
+      // adapters configured without eviction. Awaiting the RTT would
+      // double the cost of every stale read on Redis/memcached.
+      // eslint-disable-next-line promise/prefer-await-to-then -- intentional fire-and-forget
+      void this.cache.del(key).catch(() => {
+        /* swallow — best-effort eviction */
+      });
+      return undefined;
+    }
+    return stored;
+  }
+
+  async set(key: string, entry: CacheEntry): Promise<void> {
+    await this.cache.set(key, entry, deriveTtl(entry));
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return await this.cache.del(key);
+  }
+
+  async clear(): Promise<void> {
+    await this.cache.clear();
+  }
+
+  /**
+   * Read-only — does NOT evict stale entries (see `get()` for the
+   * eviction path). Keeps `has()` cheap enough to use as a predicate
+   * from caller code.
+   */
+  async has(key: string): Promise<boolean> {
+    const stored = await this.cache.get<CacheEntry>(key);
+    return stored != null && !isExpired(stored);
+  }
+}
+
+/**
+ * Translate the service's absolute `expiresAt` into cache-manager's
+ * relative TTL. A past or present timestamp collapses to `undefined`,
+ * handing control back to the `CacheModule.ttl` default so the caller
+ * isn't silently writing entries that immediately expire.
+ */
+function deriveTtl(entry: CacheEntry): number | undefined {
+  const ttl = entry.expiresAt - Date.now();
+  return ttl > 0 ? ttl : undefined;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,8 @@ export {
 } from './angular-ssr.service';
 
 // Cache implementations
-export { InMemoryCacheStorage } from './cache/in-memory-cache-storage';
+export { DEFAULT_CACHE_MAX_ENTRIES, InMemoryCacheStorage } from './cache/in-memory-cache-storage';
+export { NestCacheStorage } from './cache/nest-cache-storage';
 export { UrlCacheKeyGenerator } from './cache/url-cache-key-generator';
 
 // Debug logging

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,8 @@ export { ANGULAR_SSR_DEBUG_ENV, DebugLogger, isDebugEnabled } from './debug-logg
 
 // Interfaces
 export type {
+  AfterRenderContext,
+  AfterRenderTransform,
   AngularEngineType,
   AngularSSRModuleAsyncOptions,
   AngularSSRModuleOptions,

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -68,6 +68,29 @@ export type AngularEngineType = 'common' | 'node-app' | 'app';
 export type SkipPath = string | RegExp;
 
 /**
+ * Per-render context passed to `AfterRenderTransform` functions.
+ */
+export interface AfterRenderContext {
+  request: Request;
+  response: Response;
+  /**
+   * The full request URL (protocol + host + originalUrl). Provided so
+   * transforms don't have to reconstruct it from the Express request.
+   */
+  url: string;
+}
+
+/**
+ * A single stage in the post-render HTML transform pipeline. See the
+ * `afterRender` option on `AngularSSRModuleOptions` for pipeline
+ * semantics and cache interaction.
+ */
+export type AfterRenderTransform = (
+  html: string,
+  context: AfterRenderContext,
+) => string | Promise<string>;
+
+/**
  * Angular SSR engine instance type.
  * Supports AngularAppEngine, AngularNodeAppEngine, or CommonEngine.
  */
@@ -176,6 +199,17 @@ export interface AngularSSRModuleOptions {
    * contract on writing responses.
    */
   errorHandler?: ErrorHandler;
+
+  /**
+   * Ordered pipeline of post-render HTML transforms. Each transform sees
+   * the output of the previous one and can mutate the HTML string (inject
+   * a CSP nonce, add tracking tags, minify, rewrite asset paths, etc.).
+   *
+   * Transforms run BEFORE the cache write, so cached HTML reflects the
+   * transforms. If a transform produces per-request output that shouldn't
+   * be cached (e.g. a CSP nonce), disable caching for affected routes.
+   */
+  afterRender?: AfterRenderTransform[];
 }
 
 /**

--- a/lib/interfaces/cache-storage.interface.ts
+++ b/lib/interfaces/cache-storage.interface.ts
@@ -32,7 +32,14 @@ export interface CacheStorage {
   set(key: string, entry: CacheEntry): Promise<void> | void;
 
   /**
-   * Remove an entry from the cache
+   * Remove an entry from the cache.
+   *
+   * Returns `true` when the operation completed successfully. This mirrors
+   * `cache-manager` / Redis semantics — a missing key is not an error, so
+   * implementations SHOULD return `true` regardless of whether a key was
+   * actually removed. Callers that need "was a key removed?" information
+   * should call `has()` first.
+   *
    * @param key The cache key to remove
    */
   delete(key: string): Promise<boolean> | boolean;

--- a/package.json
+++ b/package.json
@@ -44,21 +44,32 @@
     "@angular/core": ">=19.0.0",
     "@angular/platform-server": ">=19.0.0",
     "@angular/ssr": ">=19.0.0",
+    "@nestjs/cache-manager": ">=3.0.0",
     "@nestjs/common": ">=11.0.0",
     "@nestjs/core": ">=11.0.0",
+    "cache-manager": ">=6.0.0",
     "express": ">=4.18.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": ">=7.0.0",
     "zone.js": ">=0.15.0"
   },
+  "peerDependenciesMeta": {
+    "@nestjs/cache-manager": {
+      "optional": true
+    },
+    "cache-manager": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@angular/compiler": "^19.2.21",
-    "@angular/core": "^19.0.0",
-    "@angular/platform-server": "^19.0.0",
-    "@angular/ssr": "^19.0.0",
+    "@angular/core": "^19.2.21",
+    "@angular/platform-server": "^19.2.21",
+    "@angular/ssr": "^19.2.24",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@eslint/js": "^10.0.1",
+    "@nestjs/cache-manager": "^3.1.2",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
@@ -66,6 +77,7 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.0.0",
+    "cache-manager": "^7.2.8",
     "eslint": "^10.1.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jsdoc": "^62.8.0",
@@ -78,6 +90,7 @@
     "eslint-plugin-unicorn": "^63.0.0",
     "express": "^4.21.0",
     "husky": "^9.0.0",
+    "keyv": "^5.6.0",
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "reflect-metadata": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^19.2.21
         version: 19.2.21
       '@angular/core':
-        specifier: ^19.0.0
-        version: 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
+        specifier: ^19.2.21
+        version: 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-server':
-        specifier: ^19.0.0
-        version: 19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+        specifier: ^19.2.21
+        version: 19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/ssr':
-        specifier: ^19.0.0
-        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
+        specifier: ^19.2.24
+        version: 19.2.24(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
       '@commitlint/cli':
         specifier: ^19.0.0
         version: 19.8.1(@types/node@22.19.3)(typescript@5.9.3)
@@ -29,6 +29,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
+      '@nestjs/cache-manager':
+        specifier: ^3.1.2
+        version: 3.1.2(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -50,6 +53,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9(@types/node@22.19.3)(terser@5.44.1))
+      cache-manager:
+        specifier: ^7.2.8
+        version: 7.2.8
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -86,6 +92,9 @@ importers:
       husky:
         specifier: ^9.0.0
         version: 9.1.7
+      keyv:
+        specifier: ^5.6.0
+        version: 5.6.0
       lint-staged:
         specifier: ^15.0.0
         version: 15.5.2
@@ -115,7 +124,7 @@ importers:
     dependencies:
       '@angular/ssr':
         specifier: ^19.0.0
-        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
+        version: 19.2.19(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))
       '@lexmata/nestjs-angular-ssr':
         specifier: workspace:*
         version: link:..
@@ -186,8 +195,8 @@ packages:
     resolution: {integrity: sha512-lLWXzeLPk+4kkXKpy/h0OAie3V2YImpDrzluufJ0xR8OlCffJNpanfBjm7R4tOZB7i0ONIxhsD67Z0oRhEECCQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
 
-  '@angular/core@19.2.17':
-    resolution: {integrity: sha512-nVu0ryxfiXUZ9M+NV21TY+rJZkPXTYo9U0aJb19hvByPpG+EvuujXUOgpulz6vxIzGy7pz/znRa+K9kxuuC+yQ==}
+  '@angular/core@19.2.21':
+    resolution: {integrity: sha512-jdOEwkvUyF7VdJMURXkSB1yQy595wt1lSfSgUux9tZftA7UwamCsMdidUsKqRbdaI9M3r+RdIM7qrDAWwqzz+A==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
       rxjs: ^6.5.3 || ^7.4.0
@@ -234,6 +243,17 @@ packages:
       '@angular/platform-server':
         optional: true
 
+  '@angular/ssr@19.2.24':
+    resolution: {integrity: sha512-GPbPK+9UmgQke+Apbza9aYpbg98nnsvhk9ukF6ylpLPO4qR3wF6X/vqpCEKt//G2rSdRkPUShaxQ/Rjs/aFvGg==}
+    peerDependencies:
+      '@angular/common': ^19.0.0 || ^19.2.0-next.0
+      '@angular/core': ^19.0.0 || ^19.2.0-next.0
+      '@angular/platform-server': ^19.0.0 || ^19.2.0-next.0
+      '@angular/router': ^19.0.0 || ^19.2.0-next.0
+    peerDependenciesMeta:
+      '@angular/platform-server':
+        optional: true
+
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -260,6 +280,9 @@ packages:
 
   '@borewit/text-codec@0.1.1':
     resolution: {integrity: sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==}
+
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -574,6 +597,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@ljharb/through@2.3.14':
     resolution: {integrity: sha512-ajBvlKpWucBB17FuQYUShqpqy8GRgYEpJW0vWJbUu1CV9lWyrDCapy0lScU8T8Z6qn49sSwJB3+M+evYIdGg+A==}
     engines: {node: '>= 0.4'}
@@ -584,6 +610,15 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@nestjs/cache-manager@3.1.2':
+    resolution: {integrity: sha512-Eglt8lUzC3Q3OZ2hFt4vLZ190M94YSJXUiKo67K/zlUgZQGtvxL0AYeKbG96x8+1gJTF7QhFpYw/RkQ28416Mw==}
+    peerDependencies:
+      '@nestjs/common': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0 || ^11.0.0
+      cache-manager: '>=6'
+      keyv: '>=5'
+      rxjs: ^7.8.1
 
   '@nestjs/cli@10.4.9':
     resolution: {integrity: sha512-s8qYd97bggqeK7Op3iD49X2MpFtW4LVNLAwXFkfbRxKME6IYT7X0muNTJ2+QfI8hpbNx9isWkrLWIp+g5FOhiA==}
@@ -1314,6 +1349,9 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cache-manager@7.2.8:
+    resolution: {integrity: sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2058,9 +2096,16 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -2289,6 +2334,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3436,9 +3484,9 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+  '@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
     dependencies:
-      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
       rxjs: 7.8.2
       tslib: 2.8.1
 
@@ -3446,44 +3494,53 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)':
+  '@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)':
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
       zone.js: 0.15.1
 
-  '@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))':
+  '@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))':
     dependencies:
-      '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/common': 19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+  '@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/common': 19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@angular/compiler': 19.2.21
-      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))
       rxjs: 7.8.2
       tslib: 2.8.1
       xhr2: 0.2.1
 
-  '@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+  '@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/common': 19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ssr@19.2.19(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))':
+  '@angular/ssr@19.2.19(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))':
     dependencies:
-      '@angular/common': 19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 19.2.17(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/router': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@angular/common': 19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/router': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/platform-server': 19.2.21(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.17(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@angular/platform-server': 19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+
+  '@angular/ssr@19.2.24(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-server@19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@angular/router@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))':
+    dependencies:
+      '@angular/common': 19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.21(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/router': 19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@angular/platform-server': 19.2.21(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.21)(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.17(@angular/common@19.2.17(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.21(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -3507,6 +3564,11 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@borewit/text-codec@0.1.1': {}
+
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
 
   '@colors/colors@1.5.0':
     optional: true
@@ -3796,6 +3858,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/serialize@1.1.1': {}
+
   '@ljharb/through@2.3.14':
     dependencies:
       call-bind: 1.0.8
@@ -3808,6 +3872,14 @@ snapshots:
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nestjs/cache-manager@3.1.2(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cache-manager: 7.2.8
+      keyv: 5.6.0
+      rxjs: 7.8.2
 
   '@nestjs/cli@10.4.9':
     dependencies:
@@ -4601,6 +4673,11 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cache-manager@7.2.8:
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      keyv: 5.6.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5513,9 +5590,15 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hookified@1.15.1: {}
 
   html-entities@2.6.0: {}
 
@@ -5728,6 +5811,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

Minor release. Two backward-compatible features landed on `develop` since 0.1.0:

- **#10** — `NestCacheStorage` adapter for `@nestjs/cache-manager`. Optional peer-dep so consumers on the default `InMemoryCacheStorage` aren't affected.
- **#11** — `afterRender` post-render HTML transform pipeline. New `AfterRenderTransform` / `AfterRenderContext` types exported from the package entry. Enables CSP nonce injection, minification, asset-path rewriting, etc.

No breaking changes.

## Release mechanics

1. Merge this PR into `main` (squash).
2. Back-merge to `develop` to pick up the version bump.
3. Tag `v0.2.0` on `main`.
4. `pnpm publish` from `main`.

## Verification

- 191 tests passing across 9 files.
- Coverage: 100% stmts / lines / funcs, 99.47% branches.
- Lint / typecheck / build / format all clean.

## Test plan

- [x] `pnpm test` on `release/0.2.0` at HEAD
- [ ] `pnpm publish --dry-run` from `main` after merge (will publish under `latest` dist-tag, no `--tag` flag needed)