### PR TITLE
fix(ssr): restore response headers when an afterRender transform throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,11 @@ Transforms run **before** the cache write, so cached HTML reflects the whole pip
 - Scope the caching to routes that don't need per-request transforms via `skipPaths`, or
 - Write a placeholder into the HTML and replace it via a response header / cookie rather than inlining the value.
 
-If any transform throws, the configured `errorHandler` is invoked and no further transforms run; the response falls through to `next(error)` if no handler is set.
+If any transform throws:
+
+1. No further transforms run.
+2. Any headers set by earlier transforms during this pipeline run are reverted — so if transform #1 set `Content-Security-Policy` and transform #2 threw, the error page doesn't inherit a nonce that was never applied. Headers already on the response before the pipeline started (cookies from upstream middleware, `X-Powered-By`, etc.) are preserved. Headers are not restored if they've already been flushed to the wire.
+3. The configured `errorHandler` is invoked; if no handler is set, the error propagates out of `AngularSSRService.render()` and is forwarded to `next(error)` by the middleware layer.
 
 ## Custom Cache Storage
 

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -58,12 +58,25 @@ const createMockRequest = (overrides: Partial<Request> = {}): Request =>
     ...overrides,
   }) as unknown as Request;
 
-const createMockResponse = (): Response =>
-  ({
-    setHeader: vi.fn(),
+const createMockResponse = (): Response => {
+  // In-memory Node-ish header store so `applyAfterRender`'s
+  // snapshot/restore logic can be exercised end-to-end.
+  const headers = new Map<string, string | string[] | number>();
+  return {
+    headersSent: false,
+    setHeader: vi.fn((name: string, value: string | string[] | number) => {
+      headers.set(name.toLowerCase(), value);
+    }),
+    removeHeader: vi.fn((name: string) => {
+      headers.delete(name.toLowerCase());
+    }),
+    getHeader: vi.fn((name: string) => headers.get(name.toLowerCase())),
+    getHeaderNames: vi.fn(() => [...headers.keys()]),
+    getHeaders: vi.fn(() => Object.fromEntries(headers)),
     send: vi.fn(),
     status: vi.fn().mockReturnThis(),
-  }) as unknown as Response;
+  } as unknown as Response;
+};
 
 describe('AngularSSRService', () => {
   let service: AngularSSRService;
@@ -692,6 +705,111 @@ describe('AngularSSRService', () => {
 
       await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(boom);
       expect(second).not.toHaveBeenCalled();
+    });
+
+    it('restores headers set by earlier transforms when a later transform throws', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('Content-Security-Policy', 'nonce-abc');
+            response.setHeader('X-Transform-1', 'applied');
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('Content-Security-Policy')).toBeUndefined();
+      expect(response.getHeader('X-Transform-1')).toBeUndefined();
+    });
+
+    it('preserves headers set before the pipeline runs', async () => {
+      // Headers set by upstream middleware (e.g. cookies, X-Powered-By)
+      // must survive a pipeline throw.
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('X-Added-By-Transform', 'yes');
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      response.setHeader('Set-Cookie', 'session=abc');
+      response.setHeader('X-Powered-By', 'Express');
+
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('Set-Cookie')).toBe('session=abc');
+      expect(response.getHeader('X-Powered-By')).toBe('Express');
+      expect(response.getHeader('X-Added-By-Transform')).toBeUndefined();
+    });
+
+    it('keeps headers set by successful transforms on the happy path', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('X-Transformed', 'true');
+            return html;
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('X-Transformed')).toBe('true');
+    });
+
+    it('skips header restoration once headers are already flushed', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('Content-Security-Policy', 'nonce-abc');
+            // Simulate a transform that flushed headers before the next one throws.
+            (response as unknown as { headersSent: boolean }).headersSent = true;
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      // Header persists because Node's ServerResponse can't remove headers
+      // after flush anyway — restoring would throw.
+      expect(response.getHeader('Content-Security-Policy')).toBe('nonce-abc');
+      expect(response.removeHeader).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -241,6 +241,13 @@ export class AngularSSRService implements OnModuleInit {
    *
    * Null input (the "engine produced no response" path) short-circuits —
    * transforms never see `null`.
+   *
+   * **Header isolation:** transforms commonly call `response.setHeader`
+   * (e.g. the CSP nonce pattern). If a LATER transform throws, the
+   * response headers touched by earlier transforms would otherwise leak
+   * into the error-page response — so we snapshot headers before the
+   * loop and restore the snapshot on throw, leaving the response in the
+   * state it was in before the pipeline started.
    */
   private async applyAfterRender(
     html: string | null,
@@ -250,11 +257,18 @@ export class AngularSSRService implements OnModuleInit {
     if (html === null || !transforms?.length) {
       return html;
     }
+    const { response } = context;
+    const snapshot = response.getHeaders();
     let current = html;
-    for (const transform of transforms) {
-      current = await transform(current, context);
+    try {
+      for (const transform of transforms) {
+        current = await transform(current, context);
+      }
+      return current;
+    } catch (error) {
+      restoreHeaders(response, snapshot);
+      throw error;
     }
-    return current;
   }
 
   /**
@@ -292,5 +306,34 @@ export class AngularSSRService implements OnModuleInit {
       return await this.cacheStorage.delete(key);
     }
     return false;
+  }
+}
+
+/**
+ * Restore `response`'s headers to `snapshot`: re-apply every name that was
+ * present in the snapshot (even if unchanged — cheap), and remove any name
+ * that a transform added but the snapshot didn't have. Pre-existing values
+ * take precedence so downstream middleware (`X-Powered-By` from Express,
+ * auth cookies set upstream) survive a pipeline throw intact.
+ *
+ * Headers may already be flushed when this runs; Node's ServerResponse
+ * tolerates `setHeader` / `removeHeader` after send by throwing, so we
+ * bail out early when `headersSent` is true — the response is already
+ * out the door and there's nothing to restore.
+ */
+function restoreHeaders(response: Response, snapshot: ReturnType<Response['getHeaders']>): void {
+  if (response.headersSent) {
+    return;
+  }
+  const snapshotNames = new Set(Object.keys(snapshot));
+  for (const name of response.getHeaderNames()) {
+    if (!snapshotNames.has(name)) {
+      response.removeHeader(name);
+    }
+  }
+  for (const [name, value] of Object.entries(snapshot)) {
+    if (value !== undefined) {
+      response.setHeader(name, value);
+    }
   }
 }


### PR DESCRIPTION
Addresses the code-review finding on #11 (score 75): when an `afterRender` transform calls `response.setHeader(...)` — as the README's CSP nonce example does — and a later transform throws, those headers would otherwise remain on the Response object. The error page (either from `errorHandler` or Nest's default exception filter) inherits them, producing stale CSP nonces pointing at HTML that was discarded.

## Fix

`applyAfterRender` now:

1. Captures a snapshot of `response.getHeaders()` before starting the pipeline.
2. Runs transforms inside a try/catch.
3. On throw, removes any headers a transform added and re-applies the snapshot values, leaving the response in its pre-pipeline state.
4. Skips the restore when `response.headersSent` is true — Node's `ServerResponse` can't mutate flushed headers, and the response is already out the door.

Happy-path headers set by successful transforms are preserved (the restore only runs in the catch branch). Headers set by upstream middleware (cookies, `X-Powered-By`, etc.) are preserved through throws because the snapshot captures them.

## README update

The "pipeline error handling" blurb is rewritten to:
- Explicitly call out the new header-restoration behaviour.
- Distinguish service-level `errorHandler` invocation from middleware-level `next(error)` forwarding (previously conflated, flagged by the review at score 25).

## Tests

Four new cases in `lib/angular-ssr.service.spec.ts`:
- `restores headers set by earlier transforms when a later transform throws`
- `preserves headers set before the pipeline runs`
- `keeps headers set by successful transforms on the happy path`
- `skips header restoration once headers are already flushed`

Totals: **195 tests across 9 files**, 100% stmts/funcs/lines, 99.54% branches.

## Test plan

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `pnpm test:coverage`