### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,11 @@ Transforms run **before** the cache write, so cached HTML reflects the whole pip
 - Scope the caching to routes that don't need per-request transforms via `skipPaths`, or
 - Write a placeholder into the HTML and replace it via a response header / cookie rather than inlining the value.
 
-If any transform throws, the configured `errorHandler` is invoked and no further transforms run; the response falls through to `next(error)` if no handler is set.
+If any transform throws:
+
+1. No further transforms run.
+2. Any headers set by earlier transforms during this pipeline run are reverted — so if transform #1 set `Content-Security-Policy` and transform #2 threw, the error page doesn't inherit a nonce that was never applied. Headers already on the response before the pipeline started (cookies from upstream middleware, `X-Powered-By`, etc.) are preserved. Headers are not restored if they've already been flushed to the wire.
+3. The configured `errorHandler` is invoked; if no handler is set, the error propagates out of `AngularSSRService.render()` and is forwarded to `next(error)` by the middleware layer.
 
 ## Custom Cache Storage
 

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -58,12 +58,25 @@ const createMockRequest = (overrides: Partial<Request> = {}): Request =>
     ...overrides,
   }) as unknown as Request;
 
-const createMockResponse = (): Response =>
-  ({
-    setHeader: vi.fn(),
+const createMockResponse = (): Response => {
+  // In-memory Node-ish header store so `applyAfterRender`'s
+  // snapshot/restore logic can be exercised end-to-end.
+  const headers = new Map<string, string | string[] | number>();
+  return {
+    headersSent: false,
+    setHeader: vi.fn((name: string, value: string | string[] | number) => {
+      headers.set(name.toLowerCase(), value);
+    }),
+    removeHeader: vi.fn((name: string) => {
+      headers.delete(name.toLowerCase());
+    }),
+    getHeader: vi.fn((name: string) => headers.get(name.toLowerCase())),
+    getHeaderNames: vi.fn(() => [...headers.keys()]),
+    getHeaders: vi.fn(() => Object.fromEntries(headers)),
     send: vi.fn(),
     status: vi.fn().mockReturnThis(),
-  }) as unknown as Response;
+  } as unknown as Response;
+};
 
 describe('AngularSSRService', () => {
   let service: AngularSSRService;
@@ -692,6 +705,111 @@ describe('AngularSSRService', () => {
 
       await expect(service.render(createMockRequest(), createMockResponse())).rejects.toThrow(boom);
       expect(second).not.toHaveBeenCalled();
+    });
+
+    it('restores headers set by earlier transforms when a later transform throws', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('Content-Security-Policy', 'nonce-abc');
+            response.setHeader('X-Transform-1', 'applied');
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('Content-Security-Policy')).toBeUndefined();
+      expect(response.getHeader('X-Transform-1')).toBeUndefined();
+    });
+
+    it('preserves headers set before the pipeline runs', async () => {
+      // Headers set by upstream middleware (e.g. cookies, X-Powered-By)
+      // must survive a pipeline throw.
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('X-Added-By-Transform', 'yes');
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      response.setHeader('Set-Cookie', 'session=abc');
+      response.setHeader('X-Powered-By', 'Express');
+
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('Set-Cookie')).toBe('session=abc');
+      expect(response.getHeader('X-Powered-By')).toBe('Express');
+      expect(response.getHeader('X-Added-By-Transform')).toBeUndefined();
+    });
+
+    it('keeps headers set by successful transforms on the happy path', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      service = new AngularSSRService({
+        ...mockOptions,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('X-Transformed', 'true');
+            return html;
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      expect(response.getHeader('X-Transformed')).toBe('true');
+    });
+
+    it('skips header restoration once headers are already flushed', async () => {
+      engine.handle.mockResolvedValue(mockAngularResponse('ok'));
+      const errorHandler = vi.fn();
+      service = new AngularSSRService({
+        ...mockOptions,
+        errorHandler,
+        afterRender: [
+          (html, { response }) => {
+            response.setHeader('Content-Security-Policy', 'nonce-abc');
+            // Simulate a transform that flushed headers before the next one throws.
+            (response as unknown as { headersSent: boolean }).headersSent = true;
+            return html;
+          },
+          () => {
+            throw new Error('boom');
+          },
+        ],
+      });
+      await service.onModuleInit();
+
+      const response = createMockResponse();
+      await service.render(createMockRequest(), response);
+
+      // Header persists because Node's ServerResponse can't remove headers
+      // after flush anyway — restoring would throw.
+      expect(response.getHeader('Content-Security-Policy')).toBe('nonce-abc');
+      expect(response.removeHeader).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -241,6 +241,13 @@ export class AngularSSRService implements OnModuleInit {
    *
    * Null input (the "engine produced no response" path) short-circuits —
    * transforms never see `null`.
+   *
+   * **Header isolation:** transforms commonly call `response.setHeader`
+   * (e.g. the CSP nonce pattern). If a LATER transform throws, the
+   * response headers touched by earlier transforms would otherwise leak
+   * into the error-page response — so we snapshot headers before the
+   * loop and restore the snapshot on throw, leaving the response in the
+   * state it was in before the pipeline started.
    */
   private async applyAfterRender(
     html: string | null,
@@ -250,11 +257,18 @@ export class AngularSSRService implements OnModuleInit {
     if (html === null || !transforms?.length) {
       return html;
     }
+    const { response } = context;
+    const snapshot = response.getHeaders();
     let current = html;
-    for (const transform of transforms) {
-      current = await transform(current, context);
+    try {
+      for (const transform of transforms) {
+        current = await transform(current, context);
+      }
+      return current;
+    } catch (error) {
+      restoreHeaders(response, snapshot);
+      throw error;
     }
-    return current;
   }
 
   /**
@@ -292,5 +306,34 @@ export class AngularSSRService implements OnModuleInit {
       return await this.cacheStorage.delete(key);
     }
     return false;
+  }
+}
+
+/**
+ * Restore `response`'s headers to `snapshot`: re-apply every name that was
+ * present in the snapshot (even if unchanged — cheap), and remove any name
+ * that a transform added but the snapshot didn't have. Pre-existing values
+ * take precedence so downstream middleware (`X-Powered-By` from Express,
+ * auth cookies set upstream) survive a pipeline throw intact.
+ *
+ * Headers may already be flushed when this runs; Node's ServerResponse
+ * tolerates `setHeader` / `removeHeader` after send by throwing, so we
+ * bail out early when `headersSent` is true — the response is already
+ * out the door and there's nothing to restore.
+ */
+function restoreHeaders(response: Response, snapshot: ReturnType<Response['getHeaders']>): void {
+  if (response.headersSent) {
+    return;
+  }
+  const snapshotNames = new Set(Object.keys(snapshot));
+  for (const name of response.getHeaderNames()) {
+    if (!snapshotNames.has(name)) {
+      response.removeHeader(name);
+    }
+  }
+  for (const [name, value] of Object.entries(snapshot)) {
+    if (value !== undefined) {
+      response.setHeader(name, value);
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Minor release bundling the one fix that landed on `develop` since 0.2.0:

- **#13** — `applyAfterRender` now snapshots `response.getHeaders()` before running the pipeline and restores the snapshot if a later transform throws. Prevents stale CSP nonces leaking into error pages and preserves headers set by upstream middleware through pipeline failures.

Promoted to a minor bump (not a patch) because the header-restoration semantic is an observable behaviour change: transforms that both call `response.setHeader(...)` and subsequently throw will now see their headers reverted on the error page. That's the intended fix, but a user relying on the previous (buggy) behaviour would see different output.

## Other housekeeping in this release window

- Closed #9 and #14 (dependabot bumps grouping Angular 21 core with Angular 19 SSR — incoherent). Dependabot will regenerate against the new `main` after this release lands.

## Release mechanics

1. Merge this PR into `main` (squash).
2. Back-merge / reset `develop` to match `main`.
3. Tag `v0.3.0` on `main`.
4. `pnpm publish` from `main`.

## Verification

- 195 tests passing across 9 files.
- Coverage: 100% stmts / functions / lines, 99.54% branches.
- Lint / typecheck / build / format all clean on `release/0.3.0`.

## Test plan

- [x] `pnpm test`
- [ ] `pnpm publish --dry-run` from `main` after merge (expect `latest` dist-tag, no `--tag` flag)