### PR TITLE
fix(exports): add import condition for ESM consumer resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -110,6 +110,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "require": "./dist/index.js"
     }
   },


### PR DESCRIPTION
LBP-22.

### Problem

`@lexmata/nestjs-angular-ssr@0.3.0` declares only a `require` condition in its `package.json` `exports` field. ESM consumers (Angular-built `server.mjs` in particular) cannot resolve the package — Node's ESM loader has no matching key and throws:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /app/node_modules/@lexmata/nestjs-angular-ssr/package.json imported from /app/dist/lexmata-marketing/server/server.mjs
```

Latent since v0.1.0. Surfaced in `lexmata-marketing`'s LM-89 Phase 4 staging deploy, where the NestJS SSR path is the first real ESM consumer of this library. Every prior consumer image either didn't import the library or inlined it into the Angular bundle.

### Fix

Add an `import` condition pointing at the same compiled CJS entry. Node's ESM loader loads CJS via its default-export interop, so no source changes are needed — the library stays CJS-only at build time, it just advertises itself to both module systems now.

```diff
 "exports": {
   ".": {
     "types": "./dist/index.d.ts",
+    "import": "./dist/index.js",
     "require": "./dist/index.js"
   }
 }
```

Version bumped to `0.3.1` so consumers can pin the fix.

### Verification

- `pnpm test` — 195/195 pass
- `pnpm build` — clean
- Consumer bump tracked in LM-98 (lexmata-marketing)

### Release

Merge to `develop`, then `develop → main`, then cut a GitHub release `v0.3.1` — the existing release workflow publishes to npm + GH Packages.