### PR TITLE
ci(release): drop pnpm action version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,8 +55,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm/action-setup@v4 errors when both its `version:` input and `packageManager` in package.json declare a version. `packageManager` is the source of truth. Drop the action input.

Discovered when v0.3.1 release workflow failed to publish after the LBP-22 merge.