### PR TITLE
feat(build): emit dual ESM+CJS with working Node 20 resolution

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,11 @@
+// Angular's partially-compiled libraries (e.g. @angular/common's
+// PlatformLocation) need the JIT compiler at class-definition time when
+// loaded outside an Angular platform bootstrap — which is exactly what
+// happens when this library is imported from a NestJS server entry. Load
+// the compiler eagerly so the Angular Linker has a JIT fallback available.
+// Safe everywhere: in an AOT bundle the compiler is tree-shaken out.
+import '@angular/compiler';
+
 // Middleware
 export { AngularSSRMiddleware } from './angular-ssr.middleware';
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,20 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Angular SSR (v19+) module for NestJS framework",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
-    "build:watch": "tsc --watch",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run build:fix-esm && pnpm run build:markers",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:fix-esm": "node scripts/fix-esm-extensions.mjs",
+    "build:markers": "node scripts/emit-package-json.mjs",
+    "build:watch": "tsc -p tsconfig.cjs.json --watch",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm run clean && pnpm run build",
     "test": "vitest run",
@@ -109,9 +114,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "lint-staged": {

--- a/scripts/emit-package-json.mjs
+++ b/scripts/emit-package-json.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Writes per-format `package.json` markers into dist/cjs and dist/esm.
+ *
+ * Node's ESM loader determines module type by walking up directories looking
+ * for a package.json with a `type` field. Without these markers, every `.js`
+ * file under `dist/` would inherit the root package's `type` (unset → CJS
+ * everywhere), which breaks the ESM build. The standard dual-publish trick
+ * is to drop a minimal `{"type": "module"}` next to the ESM output and
+ * `{"type": "commonjs"}` next to the CJS output.
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const targets = [
+  { dir: resolve(root, 'dist/cjs'), type: 'commonjs' },
+  { dir: resolve(root, 'dist/esm'), type: 'module' },
+];
+
+for (const { dir, type } of targets) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(resolve(dir, 'package.json'), JSON.stringify({ type }, null, 2) + '\n');
+  console.log(`wrote ${dir}/package.json (type: ${type})`);
+}

--- a/scripts/fix-esm-extensions.mjs
+++ b/scripts/fix-esm-extensions.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Rewrites extensionless relative imports in `dist/esm/**` to add `.js`.
+ *
+ * TypeScript's `module: ES2022` output uses extensionless relative
+ * specifiers — `import x from './foo'`. Node 20+ ESM requires explicit
+ * `.js` extensions on every relative import. Rather than force the source
+ * to carry extensions (which creates friction with the CJS build and with
+ * barrel-style `./interfaces` imports that resolve to `./interfaces/index`),
+ * we post-process the emitted ESM output.
+ *
+ * Handles two cases per specifier:
+ *   `./foo`           → `./foo.js`          (file)
+ *   `./foo` with ENOENT as file but ENOENT/ENOTDIR matching `./foo.js`
+ *                     → `./foo/index.js`    (directory barrel)
+ *
+ * Applies to both `.js` (emitted code) and `.d.ts` (emitted types) files.
+ */
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const esmDir = resolve(__dirname, '..', 'dist', 'esm');
+
+const RELATIVE_IMPORT_RE = /((?:from|import)\s+['"])(\.\.?\/[^'"]+?)(['"])/g;
+
+// Only treat JS-family extensions as "already resolved". A specifier like
+// `./foo.middleware` has a dot in it but is still extensionless from Node's
+// perspective — tsc uses dotted filenames freely.
+const KNOWN_EXTENSIONS = ['.js', '.mjs', '.cjs', '.json'];
+
+function hasExtension(spec) {
+  return KNOWN_EXTENSIONS.some((ext) => spec.endsWith(ext));
+}
+
+function resolveSpec(fromDir, spec) {
+  if (hasExtension(spec)) return spec;
+  const abs = resolve(fromDir, spec);
+  // Prefer file-with-extension over directory barrel, matching Node's
+  // module-resolution algorithm for CommonJS-era extensionless imports.
+  if (existsSync(`${abs}.js`)) return `${spec}.js`;
+  if (existsSync(`${abs}.d.ts`)) return `${spec}.js`;
+  if (existsSync(abs) && statSync(abs).isDirectory()) {
+    if (existsSync(join(abs, 'index.js'))) return `${spec}/index.js`;
+    if (existsSync(join(abs, 'index.d.ts'))) return `${spec}/index.js`;
+  }
+  // Give up — leave specifier untouched rather than emit a broken path.
+  return spec;
+}
+
+function rewriteFile(path) {
+  const dir = dirname(path);
+  const original = readFileSync(path, 'utf8');
+  const out = original.replace(RELATIVE_IMPORT_RE, (_, pre, spec, post) => `${pre}${resolveSpec(dir, spec)}${post}`);
+  if (out !== original) {
+    writeFileSync(path, out);
+    return true;
+  }
+  return false;
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      yield* walk(full);
+    } else if (entry.endsWith('.js') || entry.endsWith('.d.ts')) {
+      yield full;
+    }
+  }
+}
+
+let touched = 0;
+for (const file of walk(esmDir)) {
+  if (rewriteFile(file)) touched += 1;
+}
+console.log(`rewrote ${touched} file(s) under ${esmDir}`);

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs",
+    "declarationDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "./dist/esm",
+    "declarationDir": "./dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
     "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
     "rootDir": "./lib",
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Follow-up to LBP-22. v0.3.1's single-file exports map let ESM consumers resolve the package, but the CJS-under-ESM loader path still blew up at Angular's partial-compilation classes (PlatformLocation JIT failure), and ESM consumers would have hit `ERR_MODULE_NOT_FOUND` the first time they actually used the library.

## What

- Split the build into two tsc passes — CJS → `dist/cjs/`, ESM (ES2022) → `dist/esm/`. Shared base `tsconfig.json`, per-format overrides for `module`/`moduleResolution`/`outDir`.
- Emit per-format `package.json` markers (`type: commonjs` / `type: module`) so Node's ESM loader keys off the subdirectory without the root package declaring `type: module`.
- Post-build script adds `.js` extensions to relative imports in the ESM output (Node 20+ ESM requires them; TS's `module: ES2022` doesn't emit them). Handles directory barrels (`./interfaces` → `./interfaces/index.js`) and extensioned filenames (`./foo.middleware` → `./foo.middleware.js`).
- Eager `import '@angular/compiler'` at the top of `lib/index.ts` so Angular's partially-compiled libraries (`PlatformLocation` etc.) have a JIT fallback when loaded outside an Angular platform bootstrap. Tree-shakes out of AOT bundles.
- Bumped to `0.3.2`.

## Verified

Scratch sandbox with both entry points:

```
$ node --input-type=commonjs -e "require('@lexmata/nestjs-angular-ssr')"  # OK
$ node                        -e "import('@lexmata/nestjs-angular-ssr')"  # OK
```

- `pnpm test` — 195/195
- `pnpm typecheck` — clean
- `pnpm build` — emits `dist/cjs/` + `dist/esm/` with matching declaration files

## Release

Merge → sync develop → main → cut v0.3.2 → publish.