### PR TITLE
feat(ssr): add allowMissingBuild option for dev-mode boot

### DIFF
--- a/lib/angular-ssr.middleware.spec.ts
+++ b/lib/angular-ssr.middleware.spec.ts
@@ -23,13 +23,17 @@ const createMockResponse = (overrides: Partial<Response> = {}): Response =>
 
 describe('AngularSSRMiddleware', () => {
   let middleware: AngularSSRMiddleware;
-  let mockSSRService: { render: ReturnType<typeof vi.fn> };
+  let mockSSRService: {
+    render: ReturnType<typeof vi.fn>;
+    isDisabled: ReturnType<typeof vi.fn>;
+  };
   let mockOptions: AngularSSRModuleOptions;
   let mockNext: NextFunction;
 
   beforeEach(() => {
     mockSSRService = {
       render: vi.fn(),
+      isDisabled: vi.fn().mockReturnValue(false),
     };
     mockOptions = {
       browserDistFolder: '/dist/browser',
@@ -59,6 +63,17 @@ describe('AngularSSRMiddleware', () => {
 
     it('should call next for API routes', async () => {
       const request = createMockRequest({ originalUrl: '/api/users' });
+      const response = createMockResponse();
+
+      await middleware.use(request, response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockSSRService.render).not.toHaveBeenCalled();
+    });
+
+    it('bypasses SSR when the service reports itself as disabled', async () => {
+      mockSSRService.isDisabled.mockReturnValue(true);
+      const request = createMockRequest();
       const response = createMockResponse();
 
       await middleware.use(request, response, mockNext);

--- a/lib/angular-ssr.middleware.ts
+++ b/lib/angular-ssr.middleware.ts
@@ -76,6 +76,13 @@ export class AngularSSRMiddleware implements NestMiddleware {
     if (res.headersSent) {
       return 'response headers already sent';
     }
+    if (this.ssrService.isDisabled()) {
+      // `allowMissingBuild` is on and bootstrap() found no manifest. Hand
+      // the request back to Express so downstream middleware (static
+      // file handlers, 404 fallback, etc.) can respond instead of the
+      // middleware hanging on a service that never initialised.
+      return 'SSR engine disabled (allowMissingBuild)';
+    }
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       return `method ${req.method} not GET/HEAD`;
     }

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -157,6 +157,67 @@ describe('AngularSSRService', () => {
 
       await expect(service.onModuleInit()).rejects.toThrow(/resolved to undefined/);
     });
+
+    describe('allowMissingBuild', () => {
+      const makeModuleNotFoundError = (message: string): Error & { code: string } => {
+        const err = new Error(message) as Error & { code: string };
+        err.code = 'ERR_MODULE_NOT_FOUND';
+        return err;
+      };
+
+      it('swallows ERR_MODULE_NOT_FOUND when allowMissingBuild is true', async () => {
+        mockOptions.allowMissingBuild = true;
+        mockOptions.bootstrap = vi
+          .fn()
+          .mockRejectedValue(makeModuleNotFoundError("Cannot find module './manifest.mjs'"));
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).resolves.toBeUndefined();
+        expect(service.isDisabled()).toBe(true);
+      });
+
+      it('also accepts legacy MODULE_NOT_FOUND code from CommonJS require', async () => {
+        mockOptions.allowMissingBuild = true;
+        mockOptions.bootstrap = vi
+          .fn()
+          .mockRejectedValue(makeModuleNotFoundError("Cannot find module './foo'"));
+        // Swap the code to the CJS variant.
+        const bootstrapErr = new Error('cjs require miss') as Error & { code: string };
+        bootstrapErr.code = 'MODULE_NOT_FOUND';
+        mockOptions.bootstrap = vi.fn().mockRejectedValue(bootstrapErr);
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).resolves.toBeUndefined();
+        expect(service.isDisabled()).toBe(true);
+      });
+
+      it('re-throws non-module-not-found errors even when allowMissingBuild is true', async () => {
+        mockOptions.allowMissingBuild = true;
+        mockOptions.bootstrap = vi.fn().mockRejectedValue(new Error('logic bug in factory'));
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).rejects.toThrow('logic bug in factory');
+        expect(service.isDisabled()).toBe(false);
+      });
+
+      it('re-throws ERR_MODULE_NOT_FOUND when allowMissingBuild is false (default)', async () => {
+        mockOptions.bootstrap = vi
+          .fn()
+          .mockRejectedValue(makeModuleNotFoundError("Cannot find module './manifest.mjs'"));
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).rejects.toThrow(/Cannot find module/);
+        expect(service.isDisabled()).toBe(false);
+      });
+
+      it('isDisabled() stays false after a successful bootstrap', async () => {
+        mockOptions.allowMissingBuild = true;
+        service = new AngularSSRService(mockOptions);
+        await service.onModuleInit();
+
+        expect(service.isDisabled()).toBe(false);
+      });
+    });
   });
 
   describe('render() — AngularAppEngine path (default fallback)', () => {

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -29,6 +29,22 @@ export const DEFAULT_CACHE_EXPIRATION_TIME = 60_000;
 type AngularEngine = AngularAppEngine | AngularNodeAppEngine | CommonEngine;
 
 /**
+ * Narrow the thrown value to Node's "module not found" failure. That's
+ * what surfaces when `bootstrap()` does a dynamic `import()` of the
+ * Angular server manifest before `ng build` has emitted it. The helper
+ * stays strict about the `code` field so unrelated errors (type errors
+ * inside the bootstrap factory, throws from the engine constructor, etc.)
+ * still propagate.
+ */
+function isModuleNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
+}
+
+/**
  * Per-render context surfaced to Angular components via `@angular/core`'s
  * `REQUEST_CONTEXT` injection token. Available on every engine path.
  */
@@ -41,6 +57,11 @@ export interface SSRRequestContext {
 export class AngularSSRService implements OnModuleInit {
   private readonly logger = new DebugLogger(AngularSSRService.name);
   private angularEngine: AngularEngine | null = null;
+  // True when `allowMissingBuild` is set and the Angular build artefacts
+  // (manifest, server bundle) aren't present. Rendering is a no-op; the
+  // middleware asks `isDisabled()` before invoking `render()` and falls
+  // through to `next()` instead.
+  private disabled = false;
 
   private readonly cacheEnabled: boolean;
   private readonly cacheStorage: CacheStorage;
@@ -70,6 +91,22 @@ export class AngularSSRService implements OnModuleInit {
     try {
       engine = (await this.options.bootstrap()) as AngularEngine | null | undefined;
     } catch (error) {
+      // When the consumer opted into `allowMissingBuild`, swallow the
+      // specific "module not found" failure that shows up when the
+      // Angular build hasn't produced `angular-app-engine-manifest.mjs`
+      // (or an equivalent server bundle file) yet. Any other failure —
+      // logic error in the bootstrap factory, unexpected engine type,
+      // etc. — still propagates so production crashes loudly.
+      if (this.options.allowMissingBuild && isModuleNotFoundError(error)) {
+        this.disabled = true;
+        this.logger.warn(
+          `Angular SSR disabled — bootstrap() failed with ERR_MODULE_NOT_FOUND. ` +
+            `This is expected when running the backend from source before \`ng build\` ` +
+            `has emitted the server bundle. Set \`allowMissingBuild: false\` in ` +
+            `production to fail-fast on a missing manifest.`,
+        );
+        return;
+      }
       this.logger.error('Failed to initialize Angular SSR engine', error);
       throw error;
     }
@@ -84,6 +121,16 @@ export class AngularSSRService implements OnModuleInit {
     }
     this.angularEngine = engine;
     this.logger.log(`Angular SSR engine initialized (${engine.constructor.name})`);
+  }
+
+  /**
+   * True when the module was started with `allowMissingBuild: true` and
+   * the Angular bootstrap failed with a module-not-found error. Callers
+   * (principally the middleware) should skip rendering and pass the
+   * request through.
+   */
+  public isDisabled(): boolean {
+    return this.disabled;
   }
 
   private resolveCacheOptions(cache: boolean | CacheOptions | undefined): CacheOptions | false {

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -143,6 +143,26 @@ export interface AngularSSRModuleOptions {
   engineType?: AngularEngineType;
 
   /**
+   * Gracefully degrade when the Angular build artefacts aren't present at
+   * bootstrap time. Useful for dev loops where the API backend is run
+   * directly from source (e.g. `tsx src/server/main.ts`) before any
+   * `ng build` has emitted the manifest, or when a separate dev server
+   * (`ng serve`) is handling frontend SSR.
+   *
+   * When `true` and `bootstrap()` throws `ERR_MODULE_NOT_FOUND`, the
+   * service logs a warning, stays in a disabled state, and the
+   * middleware forwards every request to `next()` (no SSR). Any other
+   * bootstrap error is still thrown — only the module-not-found class
+   * is swallowed.
+   *
+   * Leave `false` in production: a missing manifest there is a real bug
+   * that should crash the container so the deploy rolls back.
+   *
+   * @default false
+   */
+  allowMissingBuild?: boolean;
+
+  /**
    * Route path(s) on which the SSR middleware will run. Default
    * `'{/*splat}'` is the NestJS 11 / Express 5 / path-to-regexp v8 splat
    * pattern that matches both root `/` and every nested path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Consumer repos using `pnpm dev` (running the API backend from source via `tsx` before any `ng build`) hit a fatal boot error when `SsrModule.bootstrap()` dynamically imports the Angular server manifest:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../server/ssr/angular-app-engine-manifest.mjs'
\`\`\`

In dev the frontend runs under \`ng serve\` on a separate port, so SSR isn't needed — the crash is pure friction. In production a missing manifest is still a real deploy bug and should crash hard.

## Fix

New option \`AngularSSRModuleOptions.allowMissingBuild\` (default \`false\`). When \`true\`:

- If \`bootstrap()\` throws with \`code === 'ERR_MODULE_NOT_FOUND'\` (or legacy CJS \`MODULE_NOT_FOUND\`), the service logs a warning, stays in a disabled state, and exposes \`isDisabled()\`.
- The middleware checks \`isDisabled()\` in its bypass logic and forwards every request to \`next()\`, so downstream Nest middleware (static files, 404 fallback) can respond instead of hanging on an uninitialised engine.
- Any other bootstrap error still propagates — only the module-not-found class is swallowed.

Default stays \`false\` so production continues to fail fast on a missing manifest.

## Tests

+6 covering:
- Service: swallows ERR_MODULE_NOT_FOUND, also accepts legacy MODULE_NOT_FOUND, re-throws non-NOT_FOUND, re-throws NOT_FOUND when flag off, \`isDisabled()\` stays false after success.
- Middleware: disabled service → next().

201/201 pass.

## Versioning

Bump 0.3.2 → 0.4.0 (new feature, no breaking changes; existing consumers without the flag set continue to fail-fast on missing builds).