### PR TITLE
fix(ssr): match swc-node's reshaped module-not-found error

### DIFF
--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -176,6 +176,29 @@ describe('AngularSSRService', () => {
         expect(service.isDisabled()).toBe(true);
       });
 
+      it('accepts plain Error with "Cannot find module ..." message (swc-node shape)', async () => {
+        // @swc-node/register rethrows dynamic import failures as plain Error
+        // with no `code` field. Fall back to message matching so the
+        // allowMissingBuild path still fires under swc-node.
+        mockOptions.allowMissingBuild = true;
+        mockOptions.bootstrap = vi
+          .fn()
+          .mockRejectedValue(new Error("Cannot find module '/app/dist/manifest.mjs'"));
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).resolves.toBeUndefined();
+        expect(service.isDisabled()).toBe(true);
+      });
+
+      it('does NOT match a generic error that lacks both code and matching message', async () => {
+        mockOptions.allowMissingBuild = true;
+        mockOptions.bootstrap = vi.fn().mockRejectedValue(new Error('some other failure'));
+        service = new AngularSSRService(mockOptions);
+
+        await expect(service.onModuleInit()).rejects.toThrow('some other failure');
+        expect(service.isDisabled()).toBe(false);
+      });
+
       it('also accepts legacy MODULE_NOT_FOUND code from CommonJS require', async () => {
         mockOptions.allowMissingBuild = true;
         mockOptions.bootstrap = vi

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -29,19 +29,26 @@ export const DEFAULT_CACHE_EXPIRATION_TIME = 60_000;
 type AngularEngine = AngularAppEngine | AngularNodeAppEngine | CommonEngine;
 
 /**
- * Narrow the thrown value to Node's "module not found" failure. That's
- * what surfaces when `bootstrap()` does a dynamic `import()` of the
- * Angular server manifest before `ng build` has emitted it. The helper
- * stays strict about the `code` field so unrelated errors (type errors
- * inside the bootstrap factory, throws from the engine constructor, etc.)
- * still propagate.
+ * Narrow the thrown value to a "module not found" failure from a dynamic
+ * `import()` inside `bootstrap()`. Native Node gives us a structured
+ * `code: 'ERR_MODULE_NOT_FOUND'` (ESM) or `'MODULE_NOT_FOUND'` (CJS),
+ * but wrappers like `@swc-node/register` strip `code` and surface a
+ * plain `Error` whose message starts with `Cannot find module` — fall
+ * back to a message match so the `allowMissingBuild` path still fires
+ * under swc-node. Other thrown values (type errors inside the bootstrap
+ * factory, throws from the engine constructor, etc.) still propagate
+ * because their messages don't begin with that string.
  */
 function isModuleNotFoundError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) {
     return false;
   }
   const code = (error as { code?: unknown }).code;
-  return code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
+  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    return true;
+  }
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && message.startsWith('Cannot find module');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

0.4.0's `allowMissingBuild` path only matched on `err.code === 'ERR_MODULE_NOT_FOUND'` (or legacy `MODULE_NOT_FOUND`). That works under native Node but **not** under `@swc-node/register`, which reshapes the error: the `code` field is stripped and only a plain `Error` with message `Cannot find module '...'` is thrown.

Consumers on swc-node (which the lexmata-marketing dev loop switched to in LM-113 because tsx doesn't emit `emitDecoratorMetadata` for NestJS GraphQL) would therefore never trigger the disabled-state fallback — the boot still crashes.

## Fix

Add a message-based fallback: when `code` is missing, check whether the message starts with `Cannot find module`. Any other thrown value still propagates because their messages don't begin with that prefix.

## Tests

+2 specs (+match swc-node-shaped error, +don't match generic error). 203/203 pass.

## Versioning

0.4.0 → 0.4.1 (bug fix).