### PR TITLE
fix(ssr): mount express.static at literal '/' to fix 301 redirect

### DIFF
--- a/lib/angular-ssr.e2e.spec.ts
+++ b/lib/angular-ssr.e2e.spec.ts
@@ -82,3 +82,70 @@ describe('AngularSSRModule (e2e wildcard routing)', () => {
     expect(service).toBeInstanceOf(AngularSSRService);
   });
 });
+
+/**
+ * Second e2e harness that boots with a real `browserDistFolder` populated
+ * with static files. Catches the regression where mounting
+ * `express.static` via `forRoutes('{/*splat}')` caused Express to issue
+ * a 301 redirect to `/favicon.ico/` instead of serving the file (LM-106).
+ */
+describe('AngularSSRModule (static asset serving)', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    tmpDir = mkdtempSync(join(tmpdir(), 'ssr-e2e-static-'));
+    writeFileSync(join(tmpDir, 'favicon.ico'), 'ICO-DATA');
+    mkdirSync(join(tmpDir, 'images'));
+    writeFileSync(join(tmpDir, 'images', 'logo.png'), 'PNG-DATA');
+
+    @Module({
+      imports: [
+        AngularSSRModule.forRoot({
+          browserDistFolder: tmpDir,
+          bootstrap: () => Promise.resolve(buildStubEngine()),
+        }),
+      ],
+    })
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class -- nest module token
+    class StaticE2EModule {}
+
+    app = await NestFactory.create(StaticE2EModule, { logger: ['error', 'warn'] });
+    await app.listen(0);
+    const server = app.getHttpServer() as { address: () => AddressInfo };
+    const port = server.address().port;
+    baseUrl = `http://127.0.0.1:${String(port)}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    const { rmSync } = await import('node:fs');
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('serves root-level static files (favicon.ico) with a 200', async () => {
+    const res = await fetch(`${baseUrl}/favicon.ico`, { redirect: 'manual' });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ICO-DATA');
+  });
+
+  it('serves nested static files (images/logo.png) with a 200', async () => {
+    const res = await fetch(`${baseUrl}/images/logo.png`, { redirect: 'manual' });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('PNG-DATA');
+  });
+
+  it('does not 301-redirect static file requests to a trailing-slash path', async () => {
+    // Regression guard for LM-106: when the static middleware was mounted
+    // via `forRoutes('{/*splat}')`, Express issued a 301 to
+    // `/favicon.ico/` instead of serving the file.
+    const res = await fetch(`${baseUrl}/favicon.ico`, { redirect: 'manual' });
+    expect(res.status).not.toBe(301);
+    expect(res.headers.get('location')).toBeNull();
+  });
+});

--- a/lib/angular-ssr.module.spec.ts
+++ b/lib/angular-ssr.module.spec.ts
@@ -188,10 +188,13 @@ describe('AngularSSRModule', () => {
       expect(applyResult.forRoutes).toHaveBeenCalledWith('{/*splat}');
     });
 
-    it('uses the splat wildcard for both static and SSR routes by default', () => {
+    it("mounts express.static at '/' and the SSR middleware at the splat wildcard by default", () => {
+      // The static middleware must mount at '/' (or an equivalent literal
+      // prefix) because `forRoutes('{/*splat}')` confuses express.static
+      // into issuing spurious 301 redirects (e.g. /favicon.ico → /favicon.ico/).
       const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '{/*splat}');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '/');
       expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '{/*splat}');
     });
 

--- a/lib/angular-ssr.module.ts
+++ b/lib/angular-ssr.module.ts
@@ -15,9 +15,20 @@ import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type { AngularSSRModuleAsyncOptions, AngularSSRModuleOptions } from './interfaces';
 
 // '{/*splat}' is the NestJS 11 / Express 5 / path-to-regexp v8 splat
-// syntax that matches both '/' and every nested path. Override via
-// renderPath / rootStaticPath for a tighter mount point.
+// syntax that matches both '/' and every nested path. Used for the SSR
+// middleware's `renderPath` default. Override via renderPath for a
+// tighter mount point.
 const DEFAULT_WILDCARD = '{/*splat}';
+
+// `express.static` misbehaves when mounted via `forRoutes('{/*splat}')` —
+// Express treats the splat as a named mount segment and strips it from
+// the incoming URL before resolving against the static root, which turns
+// `/favicon.ico` into a directory lookup and issues a spurious 301 to
+// `/favicon.ico/`. Mounting on the literal `'/'` prefix (the traditional
+// `app.use('/', express.static(...))` form) sidesteps the splat path
+// parser entirely and lets express.static match every request against
+// the browserDistFolder as intended.
+const STATIC_MOUNT_PATH = '/';
 
 @Global()
 @Module({})
@@ -68,7 +79,7 @@ export class AngularSSRModule implements NestModule {
     const staticPath =
       typeof this.options.rootStaticPath === 'string'
         ? this.options.rootStaticPath
-        : DEFAULT_WILDCARD;
+        : STATIC_MOUNT_PATH;
 
     this.logger.debug(`configure() staticPath=${staticPath} renderPaths=${renderPaths.join(',')}`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Under `forRoutes('{/*splat}')`, Express parses `{/*splat}` as a named mount segment and strips it off the URL before invoking `express.static`. The static handler then does a directory lookup on the truncated path and issues a spurious 301 redirect to `/favicon.ico/` — which obviously doesn't exist either.

Net effect for consumer apps: every `<img src="/images/...">`, `/favicon.ico`, and every other static asset returned the 301 → 404 chain instead of the bytes. This was the LM-106 blocker on lexmata-marketing's staging deploy.

## Fix

Mount `express.static` at the literal `'/'` prefix (`app.use('/', express.static(...))` — the traditional form). The SSR middleware stays on the splat wildcard because bare middleware (no `forRoutes(...)` introspection of mount path) matches requests correctly under that pattern.

## Tests

- Unit spec updated: asserts the 1st `forRoutes` is `'/'` and the 2nd (SSR) is `'{/*splat}'`.
- 3 new e2e specs using a real temp dir with real files:
  - `/favicon.ico` → 200 with file bytes
  - `/images/logo.png` → 200 with file bytes
  - 301 regression guard: no redirect, no `Location` header

206/206 pass.

## Versioning

0.4.1 → 0.4.2 (bug fix).