### PR TITLE
fix(ssr): default renderPath to '/{*splat}' + diagnose null engine responses

### DIFF
--- a/lib/angular-ssr.e2e.spec.ts
+++ b/lib/angular-ssr.e2e.spec.ts
@@ -2,7 +2,7 @@
  * End-to-end test that boots a real NestJS application with the SSR module
  * mounted, then issues real HTTP requests through Express. Exists to catch
  * regressions that mocked unit tests cannot — most importantly, that the
- * wildcard route default (`'{/*splat}'`) is actually accepted by the real
+ * wildcard route default (`'/{*splat}'`) is actually accepted by the real
  * path-to-regexp matcher inside NestJS, not just by a mocked
  * `MiddlewareConsumer`.
  */
@@ -94,7 +94,7 @@ describe('AngularSSRModule (e2e wildcard routing)', () => {
 /**
  * Second e2e harness that boots with a real `browserDistFolder` populated
  * with static files. Catches the regression where mounting
- * `express.static` via `forRoutes('{/*splat}')` caused Express to issue
+ * `express.static` via `forRoutes('/{*splat}')` caused Express to issue
  * a 301 redirect to `/favicon.ico/` instead of serving the file (LM-106).
  */
 describe('AngularSSRModule (static asset serving)', () => {
@@ -150,7 +150,7 @@ describe('AngularSSRModule (static asset serving)', () => {
 
   it('does not 301-redirect static file requests to a trailing-slash path', async () => {
     // Regression guard for LM-106: when the static middleware was mounted
-    // via `forRoutes('{/*splat}')`, Express issued a 301 to
+    // via `forRoutes('/{*splat}')`, Express issued a 301 to
     // `/favicon.ico/` instead of serving the file.
     const res = await fetch(`${baseUrl}/favicon.ico`, { redirect: 'manual' });
     expect(res.status).not.toBe(301);

--- a/lib/angular-ssr.module.spec.ts
+++ b/lib/angular-ssr.module.spec.ts
@@ -185,17 +185,17 @@ describe('AngularSSRModule', () => {
     it('uses the splat wildcard as the default render path', () => {
       const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
-      expect(applyResult.forRoutes).toHaveBeenCalledWith('{/*splat}');
+      expect(applyResult.forRoutes).toHaveBeenCalledWith('/{*splat}');
     });
 
     it("mounts express.static at '/' and the SSR middleware at the splat wildcard by default", () => {
-      // The static middleware must mount at '/' (or an equivalent literal
-      // prefix) because `forRoutes('{/*splat}')` confuses express.static
-      // into issuing spurious 301 redirects (e.g. /favicon.ico → /favicon.ico/).
+      // The static middleware must mount at '/' (a literal prefix) because
+      // `forRoutes('/{*splat}')` confuses express.static into issuing
+      // spurious 301 redirects (e.g. /favicon.ico → /favicon.ico/).
       const module = new AngularSSRModule(mockOptions);
       module.configure(mockConsumer);
       expect(applyResult.forRoutes).toHaveBeenNthCalledWith(1, '/');
-      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '{/*splat}');
+      expect(applyResult.forRoutes).toHaveBeenNthCalledWith(2, '/{*splat}');
     });
 
     it('honours a custom render path string', () => {

--- a/lib/angular-ssr.module.ts
+++ b/lib/angular-ssr.module.ts
@@ -14,11 +14,27 @@ import { DebugLogger } from './debug-logger';
 import { ANGULAR_SSR_OPTIONS } from './tokens';
 import type { AngularSSRModuleAsyncOptions, AngularSSRModuleOptions } from './interfaces';
 
-// '{/*splat}' is the NestJS 11 / Express 5 / path-to-regexp v8 splat
-// syntax that matches both '/' and every nested path. Used for the SSR
-// middleware's `renderPath` default. Override via renderPath for a
-// tighter mount point.
-const DEFAULT_WILDCARD = '{/*splat}';
+// '/{*splat}' is the only wildcard that works under BOTH NestJS 11 and
+// Express 5 / path-to-regexp v8. A brief taxonomy of patterns that
+// don't:
+//   - '*'          — passes NestJS's simple-wildcard list but under
+//                    path-to-regexp v8 it is a literal named segment
+//                    and never matches the empty root path.
+//   - '{/*splat}'  — valid under path-to-regexp v8, but NestJS 11's
+//                    `RouteInfoPathExtractor.isAWildcard()` regex
+//                    (`/^\/\{.*\}.*|^\/\*.*$/`) requires a leading
+//                    forward slash. Without one, NestJS treats the
+//                    string as a literal path and the middleware binds
+//                    to the exact string `/{*splat}` — never firing
+//                    for `/`, `/home`, or any real request. The
+//                    library shipped with this default through 0.4.2;
+//                    consumers had to override explicitly to work
+//                    around the invisible mis-binding.
+//   - '/{*splat}'  — starts with `/`, so NestJS treats it as a
+//                    wildcard. The splat body matches every path
+//                    (root + nested) under path-to-regexp v8. This
+//                    is the default every consumer wants.
+const DEFAULT_WILDCARD = '/{*splat}';
 
 // `express.static` misbehaves when mounted via `forRoutes('{/*splat}')` —
 // Express treats the splat as a named mount segment and strips it from

--- a/lib/angular-ssr.service.spec.ts
+++ b/lib/angular-ssr.service.spec.ts
@@ -376,6 +376,39 @@ describe('AngularSSRService', () => {
       expect(result).toBeNull();
     });
 
+    it('emits a one-time diagnostic warning the first time handle returns null', async () => {
+      engine.handle.mockResolvedValue(null);
+      const warnSpy = vi.spyOn(
+        (service as unknown as { logger: { warn: (m: string) => void } }).logger,
+        'warn',
+      );
+
+      await service.render(createMockRequest(), createMockResponse());
+      await service.render(createMockRequest(), createMockResponse());
+      await service.render(createMockRequest(), createMockResponse());
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/engine\.handle\(\) returned null/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/withRoutes/);
+    });
+
+    it('suppresses the diagnostic when disableNullResponseDiagnostic is true', async () => {
+      const silenced = new AngularSSRService({
+        ...mockOptions,
+        disableNullResponseDiagnostic: true,
+      });
+      await silenced.onModuleInit();
+      engine.handle.mockResolvedValue(null);
+      const warnSpy = vi.spyOn(
+        (silenced as unknown as { logger: { warn: (m: string) => void } }).logger,
+        'warn',
+      );
+
+      await silenced.render(createMockRequest(), createMockResponse());
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     it('honours an explicit engineType override even when ducktype would mismatch', async () => {
       const ducklessEngine = { handle: vi.fn() };
       ducklessEngine.handle.mockResolvedValue({

--- a/lib/angular-ssr.service.ts
+++ b/lib/angular-ssr.service.ts
@@ -74,6 +74,10 @@ export class AngularSSRService implements OnModuleInit {
   private readonly cacheStorage: CacheStorage;
   private readonly cacheKeyGenerator: CacheKeyGenerator;
   private readonly cacheExpiresIn: number;
+  // True once we've emitted the diagnostic warning for
+  // `engine.handle()` returning null. Re-firing on every request would
+  // drown real logs — we only need the one nudge.
+  private nullResponseDiagnosticEmitted = false;
 
   constructor(
     @Inject(ANGULAR_SSR_OPTIONS)
@@ -283,9 +287,64 @@ export class AngularSSRService implements OnModuleInit {
     ) => Promise<{ text: () => Promise<string> } | null | undefined> | null;
     const angularResponse = await handle(request, requestContext);
     if (!angularResponse) {
+      this.diagnoseNullEngineResponse(request);
       return null;
     }
     return await angularResponse.text();
+  }
+
+  /**
+   * `engine.handle()` returning null is a silent failure mode with
+   * three common causes:
+   *
+   *   1. No server-routes configuration. Angular 21's SSR defaults
+   *      every route to `RenderMode.Prerender`; at request time
+   *      `AngularServerApp.handleRendering()` refuses to render
+   *      Prerender routes unless `allowStaticRouteRender: true` or a
+   *      pre-built static asset exists. Fix: configure
+   *      `provideServerRendering(withRoutes([...]))` and set
+   *      `renderMode: RenderMode.Server` for routes rendered at
+   *      request time.
+   *   2. Hostname rejected by `allowedHosts`. The engine returns the
+   *      plain-text "URL with hostname '...' is not allowed" response
+   *      (status 200), so this usually doesn't surface as null —
+   *      listed here for completeness.
+   *   3. Angular route genuinely doesn't match the pathname (e.g.
+   *      the request is for a static asset that reached the SSR
+   *      middleware instead of `express.static`). The middleware's
+   *      static-file-extension bypass should catch this upstream, so
+   *      if you're seeing null for a non-asset path it almost
+   *      certainly isn't cause 3.
+   *
+   * Warning is emitted once per process lifetime to avoid log spam.
+   * Suppress entirely with `disableNullResponseDiagnostic: true` in
+   * module options.
+   */
+  private diagnoseNullEngineResponse(request: Request | globalThis.Request): void {
+    if (this.nullResponseDiagnosticEmitted) {
+      return;
+    }
+    if (this.options.disableNullResponseDiagnostic) {
+      return;
+    }
+    this.nullResponseDiagnosticEmitted = true;
+    const url =
+      'url' in request
+        ? (request as globalThis.Request).url
+        : (request as Request).originalUrl || (request as Request).url;
+    this.logger.warn(
+      `Angular SSR engine.handle() returned null for ${url}. ` +
+        `The most common cause in Angular 21+ is a missing server-routes ` +
+        `configuration — every route defaults to RenderMode.Prerender and ` +
+        `the engine refuses to render Prerender routes at request time ` +
+        `without a pre-built asset. Add ` +
+        `'provideServerRendering(withRoutes([{ path: "**", renderMode: ` +
+        `RenderMode.Server }]))' to your app.config.server.ts. See ` +
+        `https://angular.dev/guide/hybrid-rendering#withroutes for details. ` +
+        `(This warning fires once per process; set ` +
+        `disableNullResponseDiagnostic: true in AngularSSRModule options ` +
+        `to silence it.)`,
+    );
   }
 
   /**

--- a/lib/interfaces/angular-ssr-module-options.interface.ts
+++ b/lib/interfaces/angular-ssr-module-options.interface.ts
@@ -164,12 +164,33 @@ export interface AngularSSRModuleOptions {
 
   /**
    * Route path(s) on which the SSR middleware will run. Default
-   * `'{/*splat}'` is the NestJS 11 / Express 5 / path-to-regexp v8 splat
-   * pattern that matches both root `/` and every nested path.
+   * `'/{*splat}'` — the only pattern that works under BOTH NestJS 11's
+   * middleware path extractor (`RouteInfoPathExtractor.isAWildcard()`
+   * requires a leading `/`) and Express 5 / path-to-regexp v8 (where a
+   * bare `*` is a literal segment name that doesn't match the empty
+   * root path).
    *
-   * @default '{/*splat}'
+   * Prior versions (<= 0.4.2) defaulted to `'{/*splat}'` which failed
+   * Nest's wildcard check silently — the middleware bound to the
+   * literal string rather than a wildcard and never fired. Upgrading
+   * consumers on Nest 11 no longer need a manual override.
+   *
+   * @default '/{*splat}'
    */
   renderPath?: string | string[];
+
+  /**
+   * Suppress the one-time diagnostic warning emitted when
+   * `engine.handle()` returns `null` for a non-asset path. The
+   * warning helps diagnose a common Angular 21+ misconfiguration
+   * (missing `provideServerRendering(withRoutes(...))` → every route
+   * defaults to `RenderMode.Prerender` → engine refuses to render at
+   * request time → null). Set to `true` if your app intentionally
+   * returns null for some paths and the warning is noise.
+   *
+   * @default false
+   */
+  disableNullResponseDiagnostic?: boolean;
 
   /**
    * Route path on which `express.static()` will serve files from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lexmata/nestjs-angular-ssr",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Angular SSR (v19+) module for NestJS framework",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Two improvements driven by a production incident in a consumer running NestJS 11 + Express 5 + Angular 21.

### 1. Fix the shipping default `renderPath`

0.4.2 defaulted to `'{/*splat}'`. That form is valid under `path-to-regexp` v8 when tested directly (Express matches `/` and `/nested`), but NestJS 11's middleware path extractor routes through `RouteInfoPathExtractor.isAWildcard()`:

```js
/^\/\{.*\}.*|^\/\*.*$/
```

The regex requires a **leading forward slash**. Without one, NestJS treats `'{/*splat}'` as a literal path, binds the middleware to the exact string `/{/*splat}`, and the middleware never fires for any real request. The symptom: no SSR at all, Nest's catch-all returns 404 on every page.

Consumers have been working around this by passing `renderPath: '/{*splat}'` explicitly. That's the new default. `/{*splat}` starts with `/` (Nest accepts it as a wildcard) and the splat body matches every path including root under `path-to-regexp` v8.

### 2. Diagnose a silent failure mode when `engine.handle()` returns null

Angular 21+ defaults every route to `RenderMode.Prerender` when no server-routes config is provided. At request time, `AngularServerApp.handleRendering()` then refuses to render Prerender routes — `engine.handle()` returns null — unless `allowStaticRouteRender` is set or a pre-built static asset exists.

The library middleware correctly passes null through to `next()`, but the silent null is the single most confusing symptom consumers hit when missing `withRoutes()` config (it took ~3 hours of investigation on the lexmata-marketing side).

Emit a one-time-per-process warning explaining the likely cause and linking to Angular's hybrid-rendering docs. `disableNullResponseDiagnostic: true` silences it for consumers who return null intentionally.

## Breaking changes

None for consumers already overriding `renderPath`. Consumers on the bad default will start working without intervention after upgrading (strict improvement). Minor bump (0.4.2 → 0.5.0) to signal the default behaviour change.

## Test plan

- [x] `pnpm test` — 215 tests pass (was 213; added 2 for the diagnostic warning)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — CJS + ESM emit clean
- [x] e2e harnesses rely on the library default (no explicit `renderPath`) — all 14 pass with `/{*splat}`